### PR TITLE
[ACTIVITY] 활동 기록하기 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 application-db.yml
+application-s3.yml

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
 	// Log4jdbc
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
+
+	// AWS S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/otclub/humate/common/config/S3Config.java
+++ b/src/main/java/com/otclub/humate/common/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.otclub.humate.common.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3Builder() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/otclub/humate/common/entity/CompanionActivityHistory.java
+++ b/src/main/java/com/otclub/humate/common/entity/CompanionActivityHistory.java
@@ -14,12 +14,13 @@ public class CompanionActivityHistory {
     private int status; // 0 : 대기, 1 : 완료
     private Date createdAt;
     private String activityTitle;
+    private static final int PENDING_STATUS = 0;
 
     public static CompanionActivityHistory of(int companionId, int activityId) {
         return CompanionActivityHistory.builder()
                 .companionId(companionId)
                 .activityId(activityId)
-                .status(0)
+                .status(PENDING_STATUS)
                 .build();
     }
 

--- a/src/main/java/com/otclub/humate/common/entity/CompanionActivityHistory.java
+++ b/src/main/java/com/otclub/humate/common/entity/CompanionActivityHistory.java
@@ -1,9 +1,7 @@
 package com.otclub.humate.common.entity;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.Date;
 

--- a/src/main/java/com/otclub/humate/common/entity/CompanionActivityHistory.java
+++ b/src/main/java/com/otclub/humate/common/entity/CompanionActivityHistory.java
@@ -1,18 +1,28 @@
 package com.otclub.humate.common.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.Date;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
+@Builder
 public class CompanionActivityHistory {
     private int companionActivityId;
     private int companionId;
     private int activityId;
-    private int status;
+    private int status; // 0 : 대기, 1 : 완료
     private Date createdAt;
+    private String activityTitle;
+
+    public static CompanionActivityHistory of(int companionId, int activityId) {
+        return CompanionActivityHistory.builder()
+                .companionId(companionId)
+                .activityId(activityId)
+                .status(0)
+                .build();
+    }
+
 }

--- a/src/main/java/com/otclub/humate/common/entity/CompanionActivityImg.java
+++ b/src/main/java/com/otclub/humate/common/entity/CompanionActivityImg.java
@@ -1,0 +1,23 @@
+package com.otclub.humate.common.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@Builder
+public class CompanionActivityImg {
+    private int companionActivityImgId;
+    private int companionActivityId;
+    private String imgUrl;
+    private Date createdAt;
+
+    public static CompanionActivityImg of(String imgUrl) {
+        return CompanionActivityImg.builder()
+                .imgUrl(imgUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/otclub/humate/common/exception/ErrorCode.java
+++ b/src/main/java/com/otclub/humate/common/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
     DUPLICATE_KEY(409, "중복되는 아이디나 닉네임이 존재합니다. 다시 시도해주세요."),
-    UPLOAD_FAIL(400, "사진 업로드에 실패했습니다.");
+    UPLOAD_FAIL(400, "사진 업로드에 실패했습니다."),
+    ALREADY_EXISTS_ACTIVITY(409, "이미 존재하는 활동입니다. 다른 활동을 등록해 주세요.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/otclub/humate/common/exception/ErrorCode.java
+++ b/src/main/java/com/otclub/humate/common/exception/ErrorCode.java
@@ -6,8 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    DUPLICATE_KEY(409, "중복되는 아이디나 닉네임이 존재합니다. 다시 시도해주세요.");
+    DUPLICATE_KEY(409, "중복되는 아이디나 닉네임이 존재합니다. 다시 시도해주세요."),
+    UPLOAD_FAIL(400, "사진 업로드에 실패했습니다.");
 
     private final int status;
     private final String message;
-}
+    }

--- a/src/main/java/com/otclub/humate/common/upload/S3Uploader.java
+++ b/src/main/java/com/otclub/humate/common/upload/S3Uploader.java
@@ -1,0 +1,58 @@
+package com.otclub.humate.common.upload;
+
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.otclub.humate.common.exception.CustomException;
+import com.otclub.humate.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class S3Uploader {
+    private final AmazonS3 amazonS3;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadImage(MultipartFile imageFile) {
+        String originName = imageFile.getOriginalFilename();
+        String uploadName = changeRandomImageName(originName);
+
+        try {
+            log.info(bucket);
+            amazonS3.putObject(new PutObjectRequest(
+                    bucket,
+                    uploadName,
+                    imageFile.getInputStream(),
+                    createObjectMetadata(originName, imageFile.getSize())
+                    )
+            );
+
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.UPLOAD_FAIL);
+        }
+
+        return amazonS3.getUrl(bucket, uploadName).toString();
+    }
+
+    private String changeRandomImageName(String originName) {
+        return UUID.randomUUID() + "_" + originName;
+    }
+
+    private ObjectMetadata createObjectMetadata(String originName, long size) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/" + originName.substring(originName.lastIndexOf(".")));
+        metadata.setContentLength(size);
+        metadata.setCacheControl("31536000");
+        return metadata;
+    }
+}

--- a/src/main/java/com/otclub/humate/domain/activity/controller/ActivityController.java
+++ b/src/main/java/com/otclub/humate/domain/activity/controller/ActivityController.java
@@ -1,14 +1,18 @@
 package com.otclub.humate.domain.activity.controller;
 
-import com.otclub.humate.common.upload.S3Uploader;
+import com.otclub.humate.common.dto.CommonResponseDTO;
 import com.otclub.humate.domain.activity.dto.ActivitiesResponseDTO;
 import com.otclub.humate.domain.activity.dto.NewActivityResponseDTO;
+import com.otclub.humate.domain.activity.dto.UploadActivityRequestDTO;
 import com.otclub.humate.domain.activity.service.ActivityService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RequestMapping("/activities")
 @RestController
@@ -16,14 +20,12 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 public class ActivityController {
     private final ActivityService activityService;
-    private final S3Uploader s3Uploader;
 
     /**
      * 특정 동행의 활동(완료된, 새로운) 목록 조회
      *
-     * @author : 손승완
      * @param : 동행 ID
-     *
+     * @author : 손승완
      */
     @GetMapping
     public ResponseEntity<ActivitiesResponseDTO> activityList(@RequestParam("companionId") int companionId) {
@@ -32,8 +34,9 @@ public class ActivityController {
 
     /**
      * 새로운 활동 상세 조회
-     * @author : 손승완
+     *
      * @param : 활동 인증 내역 ID
+     * @author : 손승완
      */
     @GetMapping("/{activityId}")
     public ResponseEntity<NewActivityResponseDTO> NewActivityDetails(@PathVariable("activityId") int activityId) {
@@ -42,8 +45,9 @@ public class ActivityController {
 
     /**
      * 완료된 활동 상세 조회
-     * @author : 손승완
+     *
      * @param : 활동 인증 내역 ID
+     * @author : 손승완
      */
     @GetMapping("/histories/{companionActivityId}")
     public ResponseEntity<Object> finishedActivityDetails(@PathVariable("companionActivityId") int companionActivityId) {
@@ -52,22 +56,16 @@ public class ActivityController {
 
     /**
      * 활동 기록하기
+     *
+     * @param : 활동 ID, 동행 ID, 이미지 파일 목록
      * @author : 손승완
-     * @param : 활동 ID
-     * @param : 동행 ID
      */
-    @PostMapping("/upload")
-    public ResponseEntity<Object> uploadActivity(@RequestParam("activityId") int activityId,
-                                                 @RequestParam("companionId") int companionId,
-                                                 @RequestPart("image") MultipartFile imageFile) {
+    @PostMapping(value = "/upload", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<CommonResponseDTO> activityUpload(
+                                                            @RequestPart("uploadActivityRequestDTO") UploadActivityRequestDTO uploadActivityRequestDTO,
+                                                            @RequestPart("images") List<MultipartFile> images) {
 
-        // 해당 동행에 대해서 이미 올린 활동인지 먼저 검증해야한다.
-        // 이미 올렸다면 예외 처리
-
-        log.info(s3Uploader.uploadImage(imageFile));
-
-        return ResponseEntity.ok("good");
+        activityService.saveCompanionActivityHistory(uploadActivityRequestDTO, images);
+        return ResponseEntity.ok(new CommonResponseDTO(true, "활동 기록이 완료되었습니다."));
     }
-
-
 }

--- a/src/main/java/com/otclub/humate/domain/activity/controller/ActivityController.java
+++ b/src/main/java/com/otclub/humate/domain/activity/controller/ActivityController.java
@@ -1,17 +1,22 @@
 package com.otclub.humate.domain.activity.controller;
 
+import com.otclub.humate.common.upload.S3Uploader;
 import com.otclub.humate.domain.activity.dto.ActivitiesResponseDTO;
 import com.otclub.humate.domain.activity.dto.NewActivityResponseDTO;
 import com.otclub.humate.domain.activity.service.ActivityService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequestMapping("/activities")
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class ActivityController {
     private final ActivityService activityService;
+    private final S3Uploader s3Uploader;
 
     /**
      * 특정 동행의 활동(완료된, 새로운) 목록 조회
@@ -44,5 +49,25 @@ public class ActivityController {
     public ResponseEntity<Object> finishedActivityDetails(@PathVariable("companionActivityId") int companionActivityId) {
         return ResponseEntity.ok(activityService.findCompanionActivityHistory(companionActivityId));
     }
+
+    /**
+     * 활동 기록하기
+     * @author : 손승완
+     * @param : 활동 ID
+     * @param : 동행 ID
+     */
+    @PostMapping("/upload")
+    public ResponseEntity<Object> uploadActivity(@RequestParam("activityId") int activityId,
+                                                 @RequestParam("companionId") int companionId,
+                                                 @RequestPart("image") MultipartFile imageFile) {
+
+        // 해당 동행에 대해서 이미 올린 활동인지 먼저 검증해야한다.
+        // 이미 올렸다면 예외 처리
+
+        log.info(s3Uploader.uploadImage(imageFile));
+
+        return ResponseEntity.ok("good");
+    }
+
 
 }

--- a/src/main/java/com/otclub/humate/domain/activity/dto/UploadActivityRequestDTO.java
+++ b/src/main/java/com/otclub/humate/domain/activity/dto/UploadActivityRequestDTO.java
@@ -1,0 +1,13 @@
+package com.otclub.humate.domain.activity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UploadActivityRequestDTO {
+    private int activityId;
+    private int companionId;
+}

--- a/src/main/java/com/otclub/humate/domain/activity/mapper/ActivityMapper.java
+++ b/src/main/java/com/otclub/humate/domain/activity/mapper/ActivityMapper.java
@@ -1,10 +1,13 @@
 package com.otclub.humate.domain.activity.mapper;
 
 import com.otclub.humate.common.entity.Activity;
+import com.otclub.humate.common.entity.CompanionActivityHistory;
+import com.otclub.humate.common.entity.CompanionActivityImg;
 import com.otclub.humate.domain.activity.dto.CompanionActivityHistoryDetailsResponseDTO;
 import com.otclub.humate.domain.activity.dto.CompanionActivityHistoryResponseDTO;
 import com.otclub.humate.domain.activity.dto.NewActivityResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -19,4 +22,12 @@ public interface ActivityMapper {
     CompanionActivityHistoryDetailsResponseDTO selectCompanionActivityHistoryById(int companionActivityId);
 
     List<String> selectImgUrlListById(int companionActivityId);
+
+    int countCompanionActivityHistoryByIds(@Param("companionId") int companionId,
+                                        @Param("activityId") int activityId);
+    int insertCompanionActivityHistory(CompanionActivityHistory companionActivityHistory);
+
+    int insertCompanionActivityImgList(List<CompanionActivityImg> imgs);
+
+
 }

--- a/src/main/java/com/otclub/humate/domain/activity/service/ActivityService.java
+++ b/src/main/java/com/otclub/humate/domain/activity/service/ActivityService.java
@@ -3,10 +3,16 @@ package com.otclub.humate.domain.activity.service;
 import com.otclub.humate.domain.activity.dto.ActivitiesResponseDTO;
 import com.otclub.humate.domain.activity.dto.CompanionActivityHistoryDetailsResponseDTO;
 import com.otclub.humate.domain.activity.dto.NewActivityResponseDTO;
+import com.otclub.humate.domain.activity.dto.UploadActivityRequestDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public interface ActivityService {
     ActivitiesResponseDTO findActivities(int companionId);
     NewActivityResponseDTO findActivity(int activityId);
     CompanionActivityHistoryDetailsResponseDTO findCompanionActivityHistory(int companionActivityId);
+    void saveCompanionActivityHistory(UploadActivityRequestDTO uploadActivityRequestDTO, List<MultipartFile> images);
+
 
 }

--- a/src/main/java/com/otclub/humate/domain/activity/service/ActivityServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/activity/service/ActivityServiceImpl.java
@@ -1,20 +1,28 @@
 package com.otclub.humate.domain.activity.service;
 
 import com.otclub.humate.common.entity.Activity;
-import com.otclub.humate.domain.activity.dto.ActivitiesResponseDTO;
-import com.otclub.humate.domain.activity.dto.CompanionActivityHistoryDetailsResponseDTO;
-import com.otclub.humate.domain.activity.dto.CompanionActivityHistoryResponseDTO;
-import com.otclub.humate.domain.activity.dto.NewActivityResponseDTO;
+import com.otclub.humate.common.entity.CompanionActivityHistory;
+import com.otclub.humate.common.entity.CompanionActivityImg;
+import com.otclub.humate.common.exception.CustomException;
+import com.otclub.humate.common.exception.ErrorCode;
+import com.otclub.humate.common.upload.S3Uploader;
+import com.otclub.humate.domain.activity.dto.*;
 import com.otclub.humate.domain.activity.mapper.ActivityMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.sql.SQLOutput;
+import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class ActivityServiceImpl implements ActivityService {
     private final ActivityMapper activityMapper;
+    private final S3Uploader s3Uploader;
+
     @Override
     public ActivitiesResponseDTO findActivities(int companionId) {
         // 완료된 활동 목록과 새로운 활동 목록 2개를 조회해야한다.
@@ -42,5 +50,39 @@ public class ActivityServiceImpl implements ActivityService {
     @Override
     public CompanionActivityHistoryDetailsResponseDTO findCompanionActivityHistory(int companionActivityId) {
         return activityMapper.selectCompanionActivityHistoryById(companionActivityId);
+    }
+
+    @Override
+    @Transactional
+    public void saveCompanionActivityHistory(UploadActivityRequestDTO uploadActivityRequestDTO, List<MultipartFile> images) {
+        int companionId = uploadActivityRequestDTO.getCompanionId();
+        int activityId = uploadActivityRequestDTO.getActivityId();
+        isAlreadyUploadedCompanionActivityHistory(companionId, activityId);
+
+        List<CompanionActivityImg> companionActivityImgList = new ArrayList<>();
+        for (MultipartFile imageFile : images) {
+            companionActivityImgList.add(CompanionActivityImg.of(s3Uploader.uploadImage(imageFile)));
+        }
+
+        CompanionActivityHistory history = CompanionActivityHistory.of(companionId, activityId);
+        System.out.println(companionId + " " + activityId);
+        if (activityMapper.insertCompanionActivityHistory(history) != 1) {
+            throw new CustomException(ErrorCode.UPLOAD_FAIL);
+        }
+
+        for (CompanionActivityImg img : companionActivityImgList) {
+            img.setCompanionActivityId(history.getCompanionActivityId());
+        }
+
+        // bulk insert
+        if (activityMapper.insertCompanionActivityImgList(companionActivityImgList) != companionActivityImgList.size()) {
+            throw new CustomException(ErrorCode.UPLOAD_FAIL);
+        }
+    }
+
+    private void isAlreadyUploadedCompanionActivityHistory(int companionId, int activityId) {
+        if (activityMapper.countCompanionActivityHistoryByIds(companionId, activityId) != 0) {
+            throw new CustomException(ErrorCode.ALREADY_EXISTS_ACTIVITY);
+        }
     }
 }

--- a/src/main/java/com/otclub/humate/domain/activity/service/ActivityServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/activity/service/ActivityServiceImpl.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.sql.SQLOutput;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -65,7 +64,6 @@ public class ActivityServiceImpl implements ActivityService {
         }
 
         CompanionActivityHistory history = CompanionActivityHistory.of(companionId, activityId);
-        System.out.println(companionId + " " + activityId);
         if (activityMapper.insertCompanionActivityHistory(history) != 1) {
             throw new CustomException(ErrorCode.UPLOAD_FAIL);
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   config:
-    import: application-db.yml
+    import: application-db.yml, application-s3.yml
 
 mybatis:
   type-aliases-package: com.otclub.humate.domain

--- a/src/main/resources/mybatis/mapper/activity/ActivityMapper.xml
+++ b/src/main/resources/mybatis/mapper/activity/ActivityMapper.xml
@@ -6,15 +6,12 @@
     <select id="selectCompanionActivityHistoryList"
             resultType="com.otclub.humate.domain.activity.dto.CompanionActivityHistoryResponseDTO">
 
-        select cah.companion_activity_id, cah.activity_title, cah.status, cai.img_url
-        from companion_activity_history cah
-                 join (select cai1.companion_activity_id, cai1.img_url, cai1.created_at
-                       from companion_activity_img cai1
-                       where cai1.created_at = (select min(cai2.created_at)
-                                                from companion_activity_img cai2
-                                                where cai2.companion_activity_id = cai1.companion_activity_id)) cai
-                      on cah.companion_activity_id = cai.companion_activity_id
-        where cah.companion_id = #{companionId}
+        select c.companion_activity_id, a.title, c.status, min(i.img_url)
+        from companion_activity_history c
+                 left join activity a on a.activity_id = c.activity_id
+                 left join companion_activity_img i on c.companion_activity_id = i.companion_activity_id
+        where c.companion_id = #{companionId}
+        group by c.companion_activity_id, a.title, c.status
     </select>
 
     <select id="selectActivityList" resultType="com.otclub.humate.common.entity.Activity">
@@ -49,4 +46,37 @@
         where companion_activity_id = #{companionActivityId}
     </select>
 
+    <select id="countCompanionActivityHistoryByIds" resultType="java.lang.Integer">
+        select count(companion_activity_id)
+        from companion_activity_history
+        where companion_id = #{companionId} and activity_id = #{activityId}
+    </select>
+
+    <insert id="insertCompanionActivityHistory" parameterType="com.otclub.humate.common.entity.CompanionActivityHistory"
+            useGeneratedKeys="true" keyProperty="companionActivityId">
+        <selectKey keyProperty="companionActivityId" resultType="int" order="BEFORE">
+            SELECT seq_companion_activity.nextval FROM dual
+        </selectKey>
+
+        <![CDATA[
+            insert into companion_activity_history (companion_activity_id, companion_id, activity_id, status, activity_title)
+            values (#{companionActivityId}, #{companionId}, #{activityId}, #{status},
+                    (
+                    select title
+                    from activity
+                    where activity_id = #{activityId}
+                    )
+                )
+        ]]>
+    </insert>
+
+    <insert id="insertCompanionActivityImgList" parameterType="java.util.List">
+        insert into companion_activity_img(companion_activity_img_id, companion_activity_id, img_url)
+            select seq_companion_activity_img.nextval, A.* from (
+                <foreach collection="list" index="index" item="item" separator="UNION ALL">
+                    select #{item.companionActivityId}, #{item.imgUrl}
+                    from dual
+                </foreach>
+            ) A
+    </insert>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
회원이 수행한 활동을 업로드하는 기능 구현

## ⭐️ 관련 이슈
- resolved : #8 

## 📍 작업한 내용
- AWS S3에 이미지 파일 저장
- 이미 수행 완료한 활동 등의 상황에 대한 예외 처리
- DB에는 활동 인증 내역 데이터와 해당 활동에 대한 이미지 파일의 url 저장

## 🔎 결과 및 이슈 공유
- 이미 업로드한 활동일 경우
<img width="825" alt="image" src="https://github.com/user-attachments/assets/ab461780-85f4-4196-b7b7-50e9d1dfe430">

- 처음 업로드하는 활동
<img width="887" alt="image" src="https://github.com/user-attachments/assets/bf91ecfc-d3fb-480c-9aee-e5ad8faebfaa">



## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
