### PR TITLE
[MATE] 매칭글 통합 조회

### DIFF
--- a/src/main/java/com/otclub/humate/domain/mate/controller/PostController.java
+++ b/src/main/java/com/otclub/humate/domain/mate/controller/PostController.java
@@ -3,6 +3,7 @@ package com.otclub.humate.domain.mate.controller;
 import com.otclub.humate.domain.mate.dto.PostDetailResponseDTO;
 import com.otclub.humate.domain.mate.dto.PostListResponseDTO;
 import com.otclub.humate.domain.mate.dto.PostRegisterRequestDTO;
+import com.otclub.humate.domain.mate.dto.PostSearchFilterRequestDTO;
 import com.otclub.humate.domain.mate.service.PostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,9 +21,10 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping("/list")
-    public ResponseEntity<List<PostListResponseDTO>> postList() {
-        List<PostListResponseDTO> postListResponseDTOs = postService.getAllPosts();
+    public ResponseEntity<List<PostListResponseDTO>> postList(@ModelAttribute PostSearchFilterRequestDTO postSearchFilterRequestDTO) {
+        List<PostListResponseDTO> postListResponseDTOs = postService.getAllPosts(postSearchFilterRequestDTO);
         log.info("[controller단] postListResponseDTOs -> " + postListResponseDTOs);
+        log.info("gender -> " + postSearchFilterRequestDTO.getGender());
         return ResponseEntity.ok(postListResponseDTOs);
     }
 

--- a/src/main/java/com/otclub/humate/domain/mate/dto/PostListResponseDTO.java
+++ b/src/main/java/com/otclub/humate/domain/mate/dto/PostListResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.Date;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -19,8 +20,8 @@ public class PostListResponseDTO {
     private String nickname;
     // 회원 프로필 이미지
     private String profileImgUrl;
-    // 태그 내용
-    private String tagName;
+    // 태그 내용 (list 형태 - ["기타", "악세사리"]
+    private List<String> tags;
     // 게시글 제목
     private String title;
     // 매칭 날짜

--- a/src/main/java/com/otclub/humate/domain/mate/dto/PostSearchFilterRequestDTO.java
+++ b/src/main/java/com/otclub/humate/domain/mate/dto/PostSearchFilterRequestDTO.java
@@ -2,6 +2,8 @@ package com.otclub.humate.domain.mate.dto;
 
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -9,8 +11,10 @@ import lombok.*;
 @Builder
 public class PostSearchFilterRequestDTO {
 
-    // 태그 이름 목록 (형식 - "기타, 악세사리")
+    // 태그 이름 (형식 - "기타, 악세사리")
     private String tagName;
+    // 태그 이름 리스트 (형식 - ["기타", "악세사리"]
+    private List<String> tags;
     // 매칭 날짜
     private String matchDate;
     // 매칭 지점
@@ -23,5 +27,11 @@ public class PostSearchFilterRequestDTO {
     private String matchLanguage;
     // 검색 키워드
     private String keyword;
+
+    // 남자
+    private String male = "m";
+
+    // 여자
+    private String female = "f";
 
 }

--- a/src/main/java/com/otclub/humate/domain/mate/dto/PostSearchFilterRequestDTO.java
+++ b/src/main/java/com/otclub/humate/domain/mate/dto/PostSearchFilterRequestDTO.java
@@ -21,17 +21,13 @@ public class PostSearchFilterRequestDTO {
     private String matchBranch;
     // 매칭 성별 (필터링 시 설정한 원하는 성별 - 남, 여)
     private String matchGender;
+    // 회원 고유번호
+    private String memberId;
     // 회원 성별 (검색하는 사람의 성별)
     private String gender;
     // 매칭 언어
     private String matchLanguage;
     // 검색 키워드
     private String keyword;
-
-    // 남자
-    private String male = "m";
-
-    // 여자
-    private String female = "f";
 
 }

--- a/src/main/java/com/otclub/humate/domain/mate/dto/PostSearchFilterRequestDTO.java
+++ b/src/main/java/com/otclub/humate/domain/mate/dto/PostSearchFilterRequestDTO.java
@@ -1,0 +1,27 @@
+package com.otclub.humate.domain.mate.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PostSearchFilterRequestDTO {
+
+    // 태그 이름 목록 (형식 - "기타, 악세사리")
+    private String tagName;
+    // 매칭 날짜
+    private String matchDate;
+    // 매칭 지점
+    private String matchBranch;
+    // 매칭 성별 (필터링 시 설정한 원하는 성별 - 남, 여)
+    private String matchGender;
+    // 회원 성별 (검색하는 사람의 성별)
+    private String gender;
+    // 매칭 언어
+    private String matchLanguage;
+    // 검색 키워드
+    private String keyword;
+
+}

--- a/src/main/java/com/otclub/humate/domain/mate/mapper/PostMapper.java
+++ b/src/main/java/com/otclub/humate/domain/mate/mapper/PostMapper.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface PostMapper {
 
     // 매칭글 전체 목록 조회
-    List<PostListResponseDTO> selectAllPosts();
+    List<PostListResponseDTO> selectAllPosts(PostSearchFilterRequestDTO postSearchFilterRequestDTO);
 
     // 매칭글 등록
     int insertPost(Post post);

--- a/src/main/java/com/otclub/humate/domain/mate/service/PostService.java
+++ b/src/main/java/com/otclub/humate/domain/mate/service/PostService.java
@@ -3,13 +3,14 @@ package com.otclub.humate.domain.mate.service;
 import com.otclub.humate.domain.mate.dto.PostDetailResponseDTO;
 import com.otclub.humate.domain.mate.dto.PostListResponseDTO;
 import com.otclub.humate.domain.mate.dto.PostRegisterRequestDTO;
+import com.otclub.humate.domain.mate.dto.PostSearchFilterRequestDTO;
 
 import java.util.List;
 
 public interface PostService {
 
     // 게시글 전체 목록 조회
-    List<PostListResponseDTO> getAllPosts();
+    List<PostListResponseDTO> getAllPosts(PostSearchFilterRequestDTO postSearchFilterRequestDTO);
 
     // 게시글 등록
     int addPost(PostRegisterRequestDTO request);

--- a/src/main/java/com/otclub/humate/domain/mate/service/PostServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/mate/service/PostServiceImpl.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
@@ -31,6 +32,7 @@ public class PostServiceImpl implements PostService {
         if (request.getTagName() != null) {
             log.info("null값이 아닌 tagName 설정");
             preBuilder.tagName(request.getTagName());
+            preBuilder.tags(Arrays.asList(request.getTagName().split(",")));
         }
 
         if (request.getMatchDate() != null) {
@@ -60,7 +62,7 @@ public class PostServiceImpl implements PostService {
 
         PostSearchFilterRequestDTO postSearchFilterRequestDTO = preBuilder.build();
         log.info("request gender -> " + postSearchFilterRequestDTO.getGender());
-        log.info("request tagName -> " + postSearchFilterRequestDTO.getTagName());
+        log.info("request tags -> " + postSearchFilterRequestDTO.getTags());
         log.info("request matchDate -> " + postSearchFilterRequestDTO.getMatchDate());
         log.info("request matchBranch -> " + postSearchFilterRequestDTO.getMatchBranch());
         log.info("request matchGender -> " + postSearchFilterRequestDTO.getMatchGender());

--- a/src/main/java/com/otclub/humate/domain/mate/service/PostServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/mate/service/PostServiceImpl.java
@@ -26,7 +26,9 @@ public class PostServiceImpl implements PostService {
     public List<PostListResponseDTO> getAllPosts(PostSearchFilterRequestDTO request) {
         // 1. 필수값 설정
         PostSearchFilterRequestDTO.PostSearchFilterRequestDTOBuilder preBuilder
-                = PostSearchFilterRequestDTO.builder().gender(request.getGender());
+                = PostSearchFilterRequestDTO.builder()
+                    .gender(request.getGender())
+                    .memberId(request.getMemberId());
 
         // 2. null값 (optional) 설정
         if (request.getTagName() != null) {

--- a/src/main/java/com/otclub/humate/domain/mate/service/PostServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/mate/service/PostServiceImpl.java
@@ -22,8 +22,52 @@ public class PostServiceImpl implements PostService {
     private final PostMapper postMapper;
     @Override
     @Transactional
-    public List<PostListResponseDTO> getAllPosts() {
-        List<PostListResponseDTO> result = postMapper.selectAllPosts();
+    public List<PostListResponseDTO> getAllPosts(PostSearchFilterRequestDTO request) {
+        // 1. 필수값 설정
+        PostSearchFilterRequestDTO.PostSearchFilterRequestDTOBuilder preBuilder
+                = PostSearchFilterRequestDTO.builder().gender(request.getGender());
+
+        // 2. null값 (optional) 설정
+        if (request.getTagName() != null) {
+            log.info("null값이 아닌 tagName 설정");
+            preBuilder.tagName(request.getTagName());
+        }
+
+        if (request.getMatchDate() != null) {
+            log.info("null값이 아닌 matchDate 설정");
+            preBuilder.matchDate(request.getMatchDate());
+        }
+
+        if (request.getMatchBranch() != null) {
+            log.info("null값이 아닌 matchBranch 설정");
+            preBuilder.matchBranch(request.getMatchBranch());
+        }
+
+        if (request.getMatchGender() != null) {
+            log.info("null값이 아닌 matchGender 설정");
+            preBuilder.matchGender(request.getMatchGender());
+        }
+
+        if (request.getMatchLanguage() != null) {
+            log.info("null값이 아닌 matchLanguage 설정");
+            preBuilder.matchLanguage(request.getMatchLanguage());
+        }
+
+        if (request.getKeyword() != null) {
+            log.info("null값이 아닌 keyword 설정");
+            preBuilder.keyword(request.getKeyword());
+        }
+
+        PostSearchFilterRequestDTO postSearchFilterRequestDTO = preBuilder.build();
+        log.info("request gender -> " + postSearchFilterRequestDTO.getGender());
+        log.info("request tagName -> " + postSearchFilterRequestDTO.getTagName());
+        log.info("request matchDate -> " + postSearchFilterRequestDTO.getMatchDate());
+        log.info("request matchBranch -> " + postSearchFilterRequestDTO.getMatchBranch());
+        log.info("request matchGender -> " + postSearchFilterRequestDTO.getMatchGender());
+        log.info("request matchLanguage -> " + postSearchFilterRequestDTO.getMatchLanguage());
+        log.info("request keyword -> " + postSearchFilterRequestDTO.getKeyword());
+
+        List<PostListResponseDTO> result = postMapper.selectAllPosts(postSearchFilterRequestDTO);
         log.info("[service단] result -> " + result);
         return result;
     }

--- a/src/main/resources/mybatis/mapper/mate/PostMapper.xml
+++ b/src/main/resources/mybatis/mapper/mate/PostMapper.xml
@@ -2,40 +2,110 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.otclub.humate.domain.mate.mapper.PostMapper">
+
+    <!-- 검색한 게시글 목록 반환 ResultMap -->
+    <resultMap id="PostListResultMap" type="com.otclub.humate.domain.mate.dto.PostListResponseDTO">
+        <id property="postId" column="post_id"/>
+        <result property="nickname" column="nickname"/>
+        <result property="profileImgUrl" column="profile_img_url"/>
+        <result property="title" column="title"/>
+        <result property="matchDate" column="match_date"/>
+        <result property="matchBranch" column="match_branch"/>
+        <result property="matchGender" column="match_gender"/>
+        <result property="matchLanguage" column="match_language"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="isMatched" column="is_matched"/>
+        <collection property="tags" ofType="java.lang.String">
+            <result property="tagName" column="tag_name"/>
+        </collection>
+    </resultMap>
+
     <!-- 매칭글 목록 전체 조회 -->
-    <select id="selectAllPosts" resultType="com.otclub.humate.domain.mate.dto.PostListResponseDTO">
-        <![CDATA[
-            select
-                p.post_id,
-                m.nickname,
-                m.profile_img_url,
-                t.tag_name,
-                p.title,
-                p.match_date,
-                p.match_branch,
-                p.match_gender,
-                p.match_language,
-                p.created_at,
-                p.is_matched
-            from
-                post p
+    <select id="selectAllPosts"
+            parameterType="com.otclub.humate.domain.mate.dto.PostSearchFilterRequestDTO"
+            resultMap="PostListResultMap">
+        select
+            p.post_id,
+            m.nickname,
+            m.profile_img_url,
+            t.name as tag_name,
+            p.title,
+            p.match_date,
+            p.match_branch,
+            p.match_gender,
+            p.match_language,
+            p.created_at,
+            p.is_matched
+        from
+            post p
                 join member m on p.member_id = m.member_id
-                left join (
-                    select
-                        pt.post_id,
-                        listagg(t.name, ',') within group (order by t.name) as tag_name
-                    from
-                        post_tag pt
-                        join tag t on pt.tag_id = t.tag_id
-                    group by
-                        pt.post_id
-                ) t on p.post_id = t.post_id
-            where (#{tagName, jdbcType=VARCHAR} is null or t.tag_name like '%' || #{tagName, jdbcType=VARCHAR} || '%')
-              and (#{matchDate, jdbcType=VARCHAR} is null or p.match_date = #{matchDate, jdbcType=VARCHAR})
-              and (#{matchBranch, jdbcType=VARCHAR} is null or p.match_branch = #{matchBranch, jdbcType=VARCHAR})
-              and (#{matchLanguage, jdbcType=VARCHAR} is null or p.match_language like '%' || #{matchLanguage, jdbcType=VARCHAR} || '%')
-              and (#{keyword, jdbcType=VARCHAR} is null or p.title like '%' || #{keyword, jdbcType=VARCHAR})
-        ]]>
+                left join post_tag pt on p.post_id = pt.post_id
+                left join tag t on pt.tag_id = t.tag_id
+        <!-- 기본 검색 조건 -->
+        <!-- matchDate, matchBranch, matchLanguage, keyword에 대해서 검색 -->
+        where 1=1
+          and p.deleted_at is null
+        <if test="matchDate != null">
+            and p.match_date = #{matchDate, jdbcType=VARCHAR}
+        </if>
+        <if test="matchBranch != null">
+            and p.match_branch = #{matchBranch, jdbcType=VARCHAR}
+        </if>
+        <if test="matchLanguage != null">
+            and p.match_language like '%' || #{matchLanguage, jdbcType=VARCHAR} || '%'
+        </if>
+        <if test="keyword != null">
+            and p.title like '%' || #{keyword, jdbcType=VARCHAR} || '%'
+        </if>
+
+<!--        &lt;!&ndash; 검색하는 사람의 성별 및 매칭 성별에 따른 조건 &ndash;&gt;-->
+<!--        <choose>-->
+<!--            &lt;!&ndash; 검색하는 사람이 남성인 경우 &ndash;&gt;-->
+<!--            <when test="gender == 'm'">-->
+<!--                <choose>-->
+<!--                    &lt;!&ndash; 매칭 원하는 성별이 여자인 경우 &ndash;&gt;-->
+<!--                    <when test="matchGender != null and matchGender.equals(female)">-->
+<!--                        and p.match_gender = 2 and m.gender = #{female}-->
+<!--                    </when>-->
+<!--                    &lt;!&ndash; 매칭 원하는 성별이 남자인 경우 &ndash;&gt;-->
+<!--                    <when test="matchGender != null and matchGender.equals(male)">-->
+<!--                        and m.gender = #{male}-->
+<!--                    </when>-->
+<!--                    &lt;!&ndash; 매칭 원하는 성별을 선택하지 않은 경우 &ndash;&gt;-->
+<!--                    <otherwise>-->
+<!--                        and (p.match_gender = 2 or m.gender = #{male})-->
+<!--                    </otherwise>-->
+<!--                </choose>-->
+<!--            </when>-->
+
+<!--            &lt;!&ndash; 검색하는 사람이 여성인 경우 &ndash;&gt;-->
+<!--            <when test="gender == 'f'">-->
+<!--                <choose>-->
+<!--                    &lt;!&ndash; 매칭 원하는 성별이 남자인 경우 &ndash;&gt;-->
+<!--                    <when test="matchGender != null and matchGender.equals(male)">-->
+<!--                        and p.match_gender = 2 and m.gender = #{male}-->
+<!--                    </when>-->
+<!--                    &lt;!&ndash; 매칭 원하는 성별이 여자인 경우 &ndash;&gt;-->
+<!--                    <when test="matchGender != null and matchGender.equals(female)">-->
+<!--                        and m.gender = #{female}-->
+<!--                    </when>-->
+<!--                    &lt;!&ndash; 매칭 원하는 성별을 선택하지 않은 경우 &ndash;&gt;-->
+<!--                    <otherwise>-->
+<!--                        and (p.match_gender = 2 or m.gender = #{female})-->
+<!--                    </otherwise>-->
+<!--                </choose>-->
+<!--            </when>-->
+
+<!--        </choose>-->
+
+        <!-- 태그 이름 리스트에 대한 검색 -->
+        <if test="tags != null and tags.size() > 0">
+            and t.name IN
+            <foreach collection="tags" item="tag" open="(" separator="," close=")">
+                #{tag}
+            </foreach>
+        </if>
+
     </select>
 
     <!-- 매칭글 등록 -->

--- a/src/main/resources/mybatis/mapper/mate/PostMapper.xml
+++ b/src/main/resources/mybatis/mapper/mate/PostMapper.xml
@@ -58,45 +58,45 @@
             and p.title like '%' || #{keyword, jdbcType=VARCHAR} || '%'
         </if>
 
-<!--        &lt;!&ndash; 검색하는 사람의 성별 및 매칭 성별에 따른 조건 &ndash;&gt;-->
-<!--        <choose>-->
-<!--            &lt;!&ndash; 검색하는 사람이 남성인 경우 &ndash;&gt;-->
-<!--            <when test="gender == 'm'">-->
-<!--                <choose>-->
-<!--                    &lt;!&ndash; 매칭 원하는 성별이 여자인 경우 &ndash;&gt;-->
-<!--                    <when test="matchGender != null and matchGender.equals(female)">-->
-<!--                        and p.match_gender = 2 and m.gender = #{female}-->
-<!--                    </when>-->
-<!--                    &lt;!&ndash; 매칭 원하는 성별이 남자인 경우 &ndash;&gt;-->
-<!--                    <when test="matchGender != null and matchGender.equals(male)">-->
-<!--                        and m.gender = #{male}-->
-<!--                    </when>-->
-<!--                    &lt;!&ndash; 매칭 원하는 성별을 선택하지 않은 경우 &ndash;&gt;-->
-<!--                    <otherwise>-->
-<!--                        and (p.match_gender = 2 or m.gender = #{male})-->
-<!--                    </otherwise>-->
-<!--                </choose>-->
-<!--            </when>-->
+        <!-- 검색하는 사람의 성별 및 매칭 성별에 따른 조건 -->
+        <choose>
+            <!-- 검색하는 사람이 남성인 경우 -->
+            <when test='gender == "m"'>
+                <choose>
+                    <!-- 매칭 원하는 성별이 여자인 경우 -->
+                    <when test='matchGender != null and matchGender == "f"'>
+                        and p.match_gender = 2 and m.gender = 'f'
+                    </when>
+                    <!-- 매칭 원하는 성별이 남자인 경우 -->
+                    <when test='matchGender != null and matchGender == "m"'>
+                        and m.gender = 'm'
+                    </when>
+                    <!-- 매칭 원하는 성별을 선택하지 않은 경우 -->
+                    <otherwise>
+                        and (p.match_gender = 2 or m.gender = 'm')
+                    </otherwise>
+                </choose>
+            </when>
 
-<!--            &lt;!&ndash; 검색하는 사람이 여성인 경우 &ndash;&gt;-->
-<!--            <when test="gender == 'f'">-->
-<!--                <choose>-->
-<!--                    &lt;!&ndash; 매칭 원하는 성별이 남자인 경우 &ndash;&gt;-->
-<!--                    <when test="matchGender != null and matchGender.equals(male)">-->
-<!--                        and p.match_gender = 2 and m.gender = #{male}-->
-<!--                    </when>-->
-<!--                    &lt;!&ndash; 매칭 원하는 성별이 여자인 경우 &ndash;&gt;-->
-<!--                    <when test="matchGender != null and matchGender.equals(female)">-->
-<!--                        and m.gender = #{female}-->
-<!--                    </when>-->
-<!--                    &lt;!&ndash; 매칭 원하는 성별을 선택하지 않은 경우 &ndash;&gt;-->
-<!--                    <otherwise>-->
-<!--                        and (p.match_gender = 2 or m.gender = #{female})-->
-<!--                    </otherwise>-->
-<!--                </choose>-->
-<!--            </when>-->
+            <!-- 검색하는 사람이 여성인 경우 -->
+            <when test='gender == "f"'>
+                <choose>
+                    <!-- 매칭 원하는 성별이 남자인 경우 -->
+                    <when test='matchGender != null and matchGender == "m"'>
+                        and p.match_gender = 2 and m.gender = 'm'
+                    </when>
+                    <!-- 매칭 원하는 성별이 여자인 경우 -->
+                    <when test='matchGender != null and matchGender == "f"'>
+                        and m.gender = 'f'
+                    </when>
+                    <!-- 매칭 원하는 성별을 선택하지 않은 경우 -->
+                    <otherwise>
+                        and (p.match_gender = 2 or m.gender = 'f')
+                    </otherwise>
+                </choose>
+            </when>
 
-<!--        </choose>-->
+        </choose>
 
         <!-- 태그 이름 리스트에 대한 검색 -->
         <if test="tags != null and tags.size() > 0">

--- a/src/main/resources/mybatis/mapper/mate/PostMapper.xml
+++ b/src/main/resources/mybatis/mapper/mate/PostMapper.xml
@@ -30,6 +30,11 @@
                     group by
                         pt.post_id
                 ) t on p.post_id = t.post_id
+            where (#{tagName, jdbcType=VARCHAR} is null or t.tag_name like '%' || #{tagName, jdbcType=VARCHAR} || '%')
+              and (#{matchDate, jdbcType=VARCHAR} is null or p.match_date = #{matchDate, jdbcType=VARCHAR})
+              and (#{matchBranch, jdbcType=VARCHAR} is null or p.match_branch = #{matchBranch, jdbcType=VARCHAR})
+              and (#{matchLanguage, jdbcType=VARCHAR} is null or p.match_language like '%' || #{matchLanguage, jdbcType=VARCHAR} || '%')
+              and (#{keyword, jdbcType=VARCHAR} is null or p.title like '%' || #{keyword, jdbcType=VARCHAR})
         ]]>
     </select>
 

--- a/src/main/resources/mybatis/mapper/mate/PostMapper.xml
+++ b/src/main/resources/mybatis/mapper/mate/PostMapper.xml
@@ -58,6 +58,15 @@
             and p.title like '%' || #{keyword, jdbcType=VARCHAR} || '%'
         </if>
 
+        <!-- 외국인-한국인 매칭 -->
+        <if test='memberId != null and memberId.startsWith("K")'>
+            and m.member_id like 'F%'
+        </if>
+
+        <if test='memberId != null and memberId.startsWith("F")'>
+            and m.member_id like 'K%'
+        </if>
+
         <!-- 검색하는 사람의 성별 및 매칭 성별에 따른 조건 -->
         <choose>
             <!-- 검색하는 사람이 남성인 경우 -->


### PR DESCRIPTION
# 💡 PR 요약
매칭글 통합 조회 (검색+필터링) API 구현

## ⭐️ 관련 이슈
- closes : #36 

## 📍 작업한 내용
매칭글 기존 전체 조회 API에서 통합 조회로 변경
- 제목 키워드 검색 기능
- 필터링 기능 (매칭 지점, 언어, 날짜)
- 성별 기능 제외 

## 🔎 결과 및 이슈 공유
- 필터링 설정
<img width="997" alt="image" src="https://github.com/user-attachments/assets/03595ee3-8f1b-4e42-83a5-200bc82204ad">
- 제목 검색
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/b41f3d8b-78cf-44da-b73a-e6b2b2b666da">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
