### PR TITLE
[MATE] 게시글 전체 조회 태그 필터링 추가

### DIFF
--- a/src/main/java/com/otclub/humate/domain/mate/dto/PostSearchFilterRequestDTO.java
+++ b/src/main/java/com/otclub/humate/domain/mate/dto/PostSearchFilterRequestDTO.java
@@ -13,8 +13,10 @@ public class PostSearchFilterRequestDTO {
 
     // 태그 이름 (형식 - "기타, 악세사리")
     private String tagName;
-    // 태그 이름 리스트 (형식 - ["기타", "악세사리"]
+    // 태그 이름 리스트 (형식 - ["기타", "악세서리"]
     private List<String> tags;
+    // 태그 개수
+    private int tagCount;
     // 매칭 날짜
     private String matchDate;
     // 매칭 지점

--- a/src/main/java/com/otclub/humate/domain/mate/service/PostServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/mate/service/PostServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -34,7 +35,13 @@ public class PostServiceImpl implements PostService {
         if (request.getTagName() != null) {
             log.info("null값이 아닌 tagName 설정");
             preBuilder.tagName(request.getTagName());
-            preBuilder.tags(Arrays.asList(request.getTagName().split(",")));
+            List<String> tags = Arrays.stream(request.getTagName().split(","))
+                    .map(String::trim)
+                    .filter(tag -> !tag.isEmpty())
+                    .collect(Collectors.toList());
+            log.info("받은 tags -> " + tags);
+            preBuilder.tags(tags);
+            preBuilder.tagCount(tags.size());
         }
 
         if (request.getMatchDate() != null) {
@@ -70,6 +77,7 @@ public class PostServiceImpl implements PostService {
         log.info("request matchGender -> " + postSearchFilterRequestDTO.getMatchGender());
         log.info("request matchLanguage -> " + postSearchFilterRequestDTO.getMatchLanguage());
         log.info("request keyword -> " + postSearchFilterRequestDTO.getKeyword());
+        log.info("request tagCount -> " + postSearchFilterRequestDTO.getTagCount());
 
         List<PostListResponseDTO> result = postMapper.selectAllPosts(postSearchFilterRequestDTO);
         log.info("[service단] result -> " + result);

--- a/src/main/resources/mybatis/mapper/mate/PostMapper.xml
+++ b/src/main/resources/mybatis/mapper/mate/PostMapper.xml
@@ -25,26 +25,26 @@
             parameterType="com.otclub.humate.domain.mate.dto.PostSearchFilterRequestDTO"
             resultMap="PostListResultMap">
         select
-            p.post_id,
-            m.nickname,
-            m.profile_img_url,
-            t.name as tag_name,
-            p.title,
-            p.match_date,
-            p.match_branch,
-            p.match_gender,
-            p.match_language,
-            p.created_at,
-            p.is_matched
+        p.post_id,
+        m.nickname,
+        m.profile_img_url,
+        t.name as tag_name,
+        p.title,
+        p.match_date,
+        p.match_branch,
+        p.match_gender,
+        p.match_language,
+        p.created_at,
+        p.is_matched
         from
-            post p
-                join member m on p.member_id = m.member_id
-                left join post_tag pt on p.post_id = pt.post_id
-                left join tag t on pt.tag_id = t.tag_id
+        post p
+        join member m on p.member_id = m.member_id
+        left join post_tag pt on p.post_id = pt.post_id
+        left join tag t on pt.tag_id = t.tag_id
         <!-- 기본 검색 조건 -->
         <!-- matchDate, matchBranch, matchLanguage, keyword에 대해서 검색 -->
         where 1=1
-          and p.deleted_at is null
+        and p.deleted_at is null
         <if test="matchDate != null">
             and p.match_date = #{matchDate, jdbcType=VARCHAR}
         </if>
@@ -108,13 +108,19 @@
         </choose>
 
         <!-- 태그 이름 리스트에 대한 검색 -->
-        <if test="tags != null and tags.size() > 0">
-            and t.name IN
-            <foreach collection="tags" item="tag" open="(" separator="," close=")">
-                #{tag}
-            </foreach>
+        <if test="tags != null and tagCount > 0">
+            and p.post_id in (
+                select pt.post_id
+                from post_tag pt
+                join tag t on pt.tag_id = t.tag_id
+                where t.name in
+                <foreach collection="tags" item="tag" open="(" separator="," close=")">
+                    trim(#{tag})
+                </foreach>
+                group by pt.post_id
+                having count(distinct t.name) = #{tagCount}
+            )
         </if>
-
     </select>
 
     <!-- 매칭글 등록 -->


### PR DESCRIPTION
# 💡 PR 요약
게시글 전체 조회 태그 필터링 추가

## ⭐️ 관련 이슈
- closes : #53 

## 📍 작업한 내용
- 태그 리스트가 null로 들어올 때 전체 조회로 적용
- 태그 리스트 선택 시 관련 태그를 모두 포함해야 출력되도록

## 🔎 결과 및 이슈 공유
- 잘 됩니다 ~!

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
