### PR TITLE
[CHAT] 메이트 맺기 API 구현

### DIFF
--- a/src/main/java/com/otclub/humate/common/config/SecurityConfig.java
+++ b/src/main/java/com/otclub/humate/common/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
                 "/reviews/**",
                 "/redis/**",
                 "/chat/**",
-                "/ws/**");
+                "/ws/**",
+                "/mate/**");
     }
 }

--- a/src/main/java/com/otclub/humate/common/entity/ChatParticipate.java
+++ b/src/main/java/com/otclub/humate/common/entity/ChatParticipate.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 /**
  * 채팅방 참여 Entity
@@ -22,6 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@ToString
 public class ChatParticipate {
     private int participantId;
     private String memberId;

--- a/src/main/java/com/otclub/humate/common/exception/ErrorCode.java
+++ b/src/main/java/com/otclub/humate/common/exception/ErrorCode.java
@@ -17,7 +17,9 @@ public enum ErrorCode {
     FAIL_TO_DELETE_POST(400, "존재하지 않는 게시물이거나 이미 삭제된 게시물입니다."),
     FORBIDDEN_REQUEST(403, "접근할 권한이 없습니다."),
     UNEXPECTED_EXCEPTION(500, "예상하지 못한 오류가 발생했습니다. 다시 한 번 시도해주세요."),
-    ALREADY_EXISTS_PHONE(409, "이미 가입된 휴대폰 번호입니다.");
+    ALREADY_EXISTS_PHONE(409, "이미 가입된 휴대폰 번호입니다."),
+    MEMBER_NOT_FOUND(404, "존재하지 않은 유저입니다."),
+    CHAT_PARTICIPATE_NOT_FOUND(404, "해당 채팅방에 참여하지 않은 유저입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/otclub/humate/common/exception/ErrorCode.java
+++ b/src/main/java/com/otclub/humate/common/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     UNEXPECTED_EXCEPTION(500, "예상하지 못한 오류가 발생했습니다. 다시 한 번 시도해주세요."),
     ALREADY_EXISTS_PHONE(409, "이미 가입된 휴대폰 번호입니다."),
     MEMBER_NOT_FOUND(404, "존재하지 않은 유저입니다."),
-    CHAT_PARTICIPATE_NOT_FOUND(404, "해당 채팅방에 참여하지 않은 유저입니다.");
+    CHAT_PARTICIPATE_NOT_FOUND(404, "해당 채팅방에 참여하지 않은 유저입니다."),
+    CHAT_MATE_CLICK_CONFLICT(409, "이미 메이트 버튼이 처리되었습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/otclub/humate/common/service/MessagePublisher.java
+++ b/src/main/java/com/otclub/humate/common/service/MessagePublisher.java
@@ -1,9 +1,10 @@
 package com.otclub.humate.common.service;
 
+import com.otclub.humate.domain.chat.dto.ChatMessageRedisDTO;
 import com.otclub.humate.domain.chat.dto.ChatMessageRequestDTO;
 import com.otclub.humate.domain.chat.vo.ChatMessage;
 
 public interface MessagePublisher {
     void publish(String chatRoomId, String message);
-    void publish(String chatRoomId, ChatMessageRequestDTO message);
+    void publish(String chatRoomId, ChatMessageRedisDTO message);
 }

--- a/src/main/java/com/otclub/humate/common/service/RedisPublisher.java
+++ b/src/main/java/com/otclub/humate/common/service/RedisPublisher.java
@@ -1,5 +1,6 @@
 package com.otclub.humate.common.service;
 
+import com.otclub.humate.domain.chat.dto.ChatMessageRedisDTO;
 import com.otclub.humate.domain.chat.dto.ChatMessageRequestDTO;
 import com.otclub.humate.domain.chat.vo.ChatMessage;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class RedisPublisher implements MessagePublisher {
     }
 
     @Override
-    public void publish(String chatRoomId, ChatMessageRequestDTO dto){
+    public void publish(String chatRoomId, ChatMessageRedisDTO dto){
         log.info("[RedisPublisher] - publish topic : {} ", topic.getTopic());
         log.info("[RedisPublisher] - publish topic full path : {} ", topic.getTopic() + "/" + chatRoomId);
         redisTemplate.convertAndSend(topic.getTopic() + "/" + chatRoomId, dto);

--- a/src/main/java/com/otclub/humate/common/service/RedisSubscriber.java
+++ b/src/main/java/com/otclub/humate/common/service/RedisSubscriber.java
@@ -49,6 +49,13 @@ public class RedisSubscriber implements MessageListener {
             log.info("[RedisSubscriber] Redis Subscribe Channel : " + requestDTO.getContent());
             log.info("[RedisSubscriber] Redis SUB Message : {}", publishMessage);
 
+            // 공지 관련 글 (입장, 퇴장, 메이트 신청, 메이트 취소)은 구독한 모두에게 전송
+
+
+            // 채팅 글 (텍스트, 이미지)은 나를 제외한 구독한 모두에게 전송
+
+
+            // 테스트용
             //if(requestDTO.getMessageType().equals(MessageType.TEXT)) {
                 //if (sessionManager.isUserConnected(requestDTO.getSenderId())) {
                 if (requestDTO.getSenderId().equals("F_1")) {

--- a/src/main/java/com/otclub/humate/common/service/RedisSubscriber.java
+++ b/src/main/java/com/otclub/humate/common/service/RedisSubscriber.java
@@ -49,7 +49,7 @@ public class RedisSubscriber implements MessageListener {
             log.info("[RedisSubscriber] Redis Subscribe Channel : " + requestDTO.getContent());
             log.info("[RedisSubscriber] Redis SUB Message : {}", publishMessage);
 
-            if(requestDTO.getMessageType().equals(MessageType.TEXT)) {
+            //if(requestDTO.getMessageType().equals(MessageType.TEXT)) {
                 //if (sessionManager.isUserConnected(requestDTO.getSenderId())) {
                 if (requestDTO.getSenderId().equals("F_1")) {
                     WebSocketSession session = sessionManager.getSession("K_1");
@@ -63,7 +63,7 @@ public class RedisSubscriber implements MessageListener {
                         log.error(e.getMessage());
                     }
                 }
-            }
+           // }
         }
         catch (JsonProcessingException e){
             log.error(e.getMessage());

--- a/src/main/java/com/otclub/humate/domain/chat/controller/MateController.java
+++ b/src/main/java/com/otclub/humate/domain/chat/controller/MateController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MateController {
     private final MateService mateService;
 
-    @PostMapping("/new")
+    @PostMapping("/update")
     public ResponseEntity<CommonResponseDTO> mateModify(@RequestBody MateCreateRequestDTO request) {
 
         mateService.modifyMate(request);

--- a/src/main/java/com/otclub/humate/domain/chat/controller/MateController.java
+++ b/src/main/java/com/otclub/humate/domain/chat/controller/MateController.java
@@ -1,0 +1,29 @@
+package com.otclub.humate.domain.chat.controller;
+
+
+import com.otclub.humate.common.dto.CommonResponseDTO;
+import com.otclub.humate.domain.chat.dto.MateCreateRequestDTO;
+import com.otclub.humate.domain.chat.service.MateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/mate")
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class MateController {
+    private final MateService mateService;
+
+    @PostMapping("/new")
+    public ResponseEntity<CommonResponseDTO> mateModify(@RequestBody MateCreateRequestDTO request) {
+
+        mateService.modifyMate(request);
+        log.info("[MateController] - 메이트 업데이트 {}", request.toString());
+        return ResponseEntity.ok(new CommonResponseDTO(true, "메이트 업데이트가 완료되었습니다."));
+    }
+}

--- a/src/main/java/com/otclub/humate/domain/chat/dto/ChatMessageRedisDTO.java
+++ b/src/main/java/com/otclub/humate/domain/chat/dto/ChatMessageRedisDTO.java
@@ -1,0 +1,41 @@
+package com.otclub.humate.domain.chat.dto;
+
+import com.otclub.humate.common.entity.ChatRoom;
+import com.otclub.humate.common.entity.Member;
+import com.otclub.humate.domain.chat.vo.MessageType;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+public class ChatMessageRedisDTO {
+    private String chatRoomId;
+    private String senderId;
+    private String content;
+    private MessageType messageType;
+
+    public static ChatMessageRedisDTO from(ChatMessageRequestDTO requestDTO){
+        return ChatMessageRedisDTO.builder()
+                .chatRoomId(requestDTO.getChatRoomId())
+                .senderId(requestDTO.getSenderId())
+                .content(requestDTO.getContent())
+                .messageType(requestDTO.getMessageType())
+                .build();
+    }
+
+    public static ChatMessageRedisDTO ofMateActive(MateCreateRequestDTO requestDTO, String nickname){
+        return ChatMessageRedisDTO.builder()
+                .chatRoomId(requestDTO.getChatRoomId())
+                .senderId(requestDTO.getMemberId())
+                .content(nickname + MessageType.MATE_ACTIVE.getMsg())
+                .messageType(MessageType.MATE_ACTIVE)
+                .build();
+    }
+}

--- a/src/main/java/com/otclub/humate/domain/chat/dto/ChatMessageRedisDTO.java
+++ b/src/main/java/com/otclub/humate/domain/chat/dto/ChatMessageRedisDTO.java
@@ -31,11 +31,13 @@ public class ChatMessageRedisDTO {
     }
 
     public static ChatMessageRedisDTO ofMateActive(MateCreateRequestDTO requestDTO, String nickname){
+        MessageType messageType = (requestDTO.getIsClicked()==1 ? MessageType.MATE_ACTIVE : MessageType.MATE_INACTIVE);
+
         return ChatMessageRedisDTO.builder()
                 .chatRoomId(requestDTO.getChatRoomId())
                 .senderId(requestDTO.getMemberId())
-                .content(nickname + MessageType.MATE_ACTIVE.getMsg())
-                .messageType(MessageType.MATE_ACTIVE)
+                .content(nickname + messageType.getMsg())
+                .messageType(messageType.MATE_ACTIVE)
                 .build();
     }
 }

--- a/src/main/java/com/otclub/humate/domain/chat/dto/MateCreateRequestDTO.java
+++ b/src/main/java/com/otclub/humate/domain/chat/dto/MateCreateRequestDTO.java
@@ -1,0 +1,17 @@
+package com.otclub.humate.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MateCreateRequestDTO {
+    private String chatRoomId;
+    private String memberId;
+    private int isClicked;
+}

--- a/src/main/java/com/otclub/humate/domain/chat/mapper/ChatRoomMapper.java
+++ b/src/main/java/com/otclub/humate/domain/chat/mapper/ChatRoomMapper.java
@@ -2,7 +2,9 @@ package com.otclub.humate.domain.chat.mapper;
 
 import com.otclub.humate.common.entity.ChatParticipate;
 import com.otclub.humate.common.entity.ChatRoom;
+import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 /**
  * 채팅방 Mapper
@@ -13,6 +15,7 @@ import org.apache.ibatis.annotations.Mapper;
  * <pre>
  * 수정일        	수정자        수정내용
  * ----------  --------    ---------------------------
+ * 2024.08.03   최유경        회원 참여 확인 메서드
  * 2024.07.28  	최유경        최초 생성
  * </pre>
  */
@@ -20,6 +23,7 @@ import org.apache.ibatis.annotations.Mapper;
 public interface ChatRoomMapper {
     int insertChatRoom(ChatRoom chatRoom);
     int insertChatParticipant(ChatParticipate chatParticipate);
+    Optional<ChatParticipate> selectChatParticipantByChatRoomIdAndMemberId(@Param("chatRoomId") String chatRoomId, @Param("memberId") String memberId);
 
 
 }

--- a/src/main/java/com/otclub/humate/domain/chat/mapper/MateMapper.java
+++ b/src/main/java/com/otclub/humate/domain/chat/mapper/MateMapper.java
@@ -1,0 +1,11 @@
+package com.otclub.humate.domain.chat.mapper;
+
+
+import com.otclub.humate.domain.chat.dto.MateCreateRequestDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface MateMapper {
+    int updateMate(MateCreateRequestDTO requestDTO);
+
+}

--- a/src/main/java/com/otclub/humate/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/ChatMessageService.java
@@ -1,5 +1,6 @@
 package com.otclub.humate.domain.chat.service;
 
+import com.otclub.humate.domain.chat.dto.ChatMessageRedisDTO;
 import com.otclub.humate.domain.chat.dto.ChatMessageRequestDTO;
 import com.otclub.humate.domain.chat.vo.ChatMessage;
 import java.util.List;
@@ -18,7 +19,7 @@ import java.util.List;
  * </pre>
  */
 public interface ChatMessageService {
-    ChatMessage createMessage(String roomId, ChatMessageRequestDTO requestDTO);
+    ChatMessage createMessage(String roomId, ChatMessageRedisDTO requestDTO);
 
     List<ChatMessage> getListMessage(String roomId);
 }

--- a/src/main/java/com/otclub/humate/domain/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/ChatMessageServiceImpl.java
@@ -1,5 +1,6 @@
 package com.otclub.humate.domain.chat.service;
 
+import com.otclub.humate.domain.chat.dto.ChatMessageRedisDTO;
 import com.otclub.humate.domain.chat.dto.ChatMessageRequestDTO;
 import com.otclub.humate.domain.chat.vo.ChatMessage;
 import java.util.List;
@@ -31,7 +32,7 @@ public class ChatMessageServiceImpl implements ChatMessageService{
     private final MongoTemplate mongoTemplate;
 
     @Override
-    public ChatMessage createMessage(String chatRoomId, ChatMessageRequestDTO requestDTO) {
+    public ChatMessage createMessage(String chatRoomId, ChatMessageRedisDTO requestDTO) {
         ChatMessage chatMessage = ChatMessage.of(chatRoomId, requestDTO);
 
         // 몽고디비 저장하기

--- a/src/main/java/com/otclub/humate/domain/chat/service/MateService.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/MateService.java
@@ -1,0 +1,7 @@
+package com.otclub.humate.domain.chat.service;
+
+import com.otclub.humate.domain.chat.dto.MateCreateRequestDTO;
+
+public interface MateService {
+    void modifyMate(MateCreateRequestDTO requestDTO) ;
+}

--- a/src/main/java/com/otclub/humate/domain/chat/service/MateService.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/MateService.java
@@ -2,6 +2,18 @@ package com.otclub.humate.domain.chat.service;
 
 import com.otclub.humate.domain.chat.dto.MateCreateRequestDTO;
 
+/**
+ * 메이트 관련 서비스
+ * @author 최유경
+ * @since 2024.08.03
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.03  	최유경        최초 생성
+ * </pre>
+ */
 public interface MateService {
     void modifyMate(MateCreateRequestDTO requestDTO) ;
 }

--- a/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
@@ -8,10 +8,12 @@ import com.otclub.humate.domain.chat.dto.MateCreateRequestDTO;
 import com.otclub.humate.domain.chat.mapper.MateMapper;
 import com.otclub.humate.domain.member.mapper.MemberMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MateServiceImpl implements MateService {
     private final MateMapper mateMapper;
     private final MemberMapper memberMapper;
@@ -20,8 +22,8 @@ public class MateServiceImpl implements MateService {
     @Override
     public void modifyMate(MateCreateRequestDTO requestDTO) {
         // 회원 조회하기
-        Member member = memberMapper.selectMemberById(requestDTO.getMemberId());
-
+        Member member = memberMapper.selectMemberDetail(requestDTO.getMemberId());
+        log.info("[MateServiceImpl] - member : {}", member.toString());
         if (member == null) {
             throw new CustomException(ErrorCode.FORBIDDEN_REQUEST);
         }
@@ -31,9 +33,8 @@ public class MateServiceImpl implements MateService {
             throw new CustomException(ErrorCode.FORBIDDEN_REQUEST);
         }
 
-//
-//        // 메이트 안내 채팅 전송하기
-//        ChatMessageRedisDTO redisDTO = ChatMessageRedisDTO.ofMateActive(requestDTO, member.getNickname());
-//        redisPubSubService.pubSendMessageChannel(redisDTO);
+        // 메이트 안내 채팅 전송하기
+        ChatMessageRedisDTO redisDTO = ChatMessageRedisDTO.ofMateActive(requestDTO, member.getNickname());
+        redisPubSubService.pubSendMessageChannel(redisDTO);
     }
 }

--- a/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
@@ -1,32 +1,49 @@
 package com.otclub.humate.domain.chat.service;
 
+import com.otclub.humate.common.entity.ChatParticipate;
 import com.otclub.humate.common.entity.Member;
 import com.otclub.humate.common.exception.CustomException;
 import com.otclub.humate.common.exception.ErrorCode;
 import com.otclub.humate.domain.chat.dto.ChatMessageRedisDTO;
 import com.otclub.humate.domain.chat.dto.MateCreateRequestDTO;
+import com.otclub.humate.domain.chat.mapper.ChatRoomMapper;
 import com.otclub.humate.domain.chat.mapper.MateMapper;
 import com.otclub.humate.domain.member.mapper.MemberMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+/**
+ * 메이트 관련 서비스
+ * @author 최유경
+ * @since 2024.08.03
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.03  	최유경        최초 생성
+ * </pre>
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class MateServiceImpl implements MateService {
     private final MateMapper mateMapper;
+    private final ChatRoomMapper chatRoomMapper;
     private final MemberMapper memberMapper;
     private final RedisPubSubService redisPubSubService;
 
     @Override
     public void modifyMate(MateCreateRequestDTO requestDTO) {
         // 회원 조회하기
-        Member member = memberMapper.selectMemberDetail(requestDTO.getMemberId());
+        Member member = memberMapper.selectMemberDetail(requestDTO.getMemberId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
         log.info("[MateServiceImpl] - member : {}", member.toString());
-        if (member == null) {
-            throw new CustomException(ErrorCode.FORBIDDEN_REQUEST);
-        }
+
+        // 채팅방에 참여한 회원인지 확인하기
+        ChatParticipate chatParticipate = chatRoomMapper.selectChatParticipantByChatRoomIdAndMemberId(requestDTO.getChatRoomId(), requestDTO.getMemberId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_PARTICIPATE_NOT_FOUND));
 
         // 메이트 신청하기
         if (mateMapper.updateMate(requestDTO) == 0){

--- a/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
@@ -1,0 +1,39 @@
+package com.otclub.humate.domain.chat.service;
+
+import com.otclub.humate.common.entity.Member;
+import com.otclub.humate.common.exception.CustomException;
+import com.otclub.humate.common.exception.ErrorCode;
+import com.otclub.humate.domain.chat.dto.ChatMessageRedisDTO;
+import com.otclub.humate.domain.chat.dto.MateCreateRequestDTO;
+import com.otclub.humate.domain.chat.mapper.MateMapper;
+import com.otclub.humate.domain.member.mapper.MemberMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MateServiceImpl implements MateService {
+    private final MateMapper mateMapper;
+    private final MemberMapper memberMapper;
+    private final RedisPubSubService redisPubSubService;
+
+    @Override
+    public void modifyMate(MateCreateRequestDTO requestDTO) {
+        // 회원 조회하기
+        Member member = memberMapper.selectMemberById(requestDTO.getMemberId());
+
+        if (member == null) {
+            throw new CustomException(ErrorCode.FORBIDDEN_REQUEST);
+        }
+
+        // 메이트 신청하기
+        if (mateMapper.updateMate(requestDTO) == 0){
+            throw new CustomException(ErrorCode.FORBIDDEN_REQUEST);
+        }
+
+//
+//        // 메이트 안내 채팅 전송하기
+//        ChatMessageRedisDTO redisDTO = ChatMessageRedisDTO.ofMateActive(requestDTO, member.getNickname());
+//        redisPubSubService.pubSendMessageChannel(redisDTO);
+    }
+}

--- a/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
@@ -46,6 +46,10 @@ public class MateServiceImpl implements MateService {
                 .orElseThrow(() -> new CustomException(ErrorCode.CHAT_PARTICIPATE_NOT_FOUND));
         log.info("[[MateServiceImpl] - chatParticipate : {} ", chatParticipate.toString());
 
+        // 이미 처리된 내용에 대해 예외 처리
+        if(chatParticipate.getIsClicked() == requestDTO.getIsClicked())
+            throw new CustomException(ErrorCode.CHAT_MATE_CLICK_CONFLICT);
+
         // 메이트 신청하기
         if (mateMapper.updateMate(requestDTO) == 0){
             throw new CustomException(ErrorCode.FORBIDDEN_REQUEST);

--- a/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
@@ -44,6 +44,7 @@ public class MateServiceImpl implements MateService {
         // 채팅방에 참여한 회원인지 확인하기
         ChatParticipate chatParticipate = chatRoomMapper.selectChatParticipantByChatRoomIdAndMemberId(requestDTO.getChatRoomId(), requestDTO.getMemberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.CHAT_PARTICIPATE_NOT_FOUND));
+        log.info("[[MateServiceImpl] - chatParticipate : {} ", chatParticipate.toString());
 
         // 메이트 신청하기
         if (mateMapper.updateMate(requestDTO) == 0){

--- a/src/main/java/com/otclub/humate/domain/chat/service/RedisPubSubService.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/RedisPubSubService.java
@@ -2,7 +2,9 @@ package com.otclub.humate.domain.chat.service;
 
 import com.otclub.humate.common.service.RedisPublisher;
 import com.otclub.humate.common.service.RedisSubscriber;
+import com.otclub.humate.domain.chat.dto.ChatMessageRedisDTO;
 import com.otclub.humate.domain.chat.dto.ChatMessageRequestDTO;
+import com.otclub.humate.domain.chat.dto.MateCreateRequestDTO;
 import com.otclub.humate.domain.chat.vo.ChatMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,14 +30,28 @@ public class RedisPubSubService {
     public void pubSendMessageChannel(ChatMessageRequestDTO requestDTO){
         // 요청한 Channel 을 구독
         listenerContainer.addMessageListener(redisSubscriber, new ChannelTopic(topic.getTopic() + "/" + requestDTO.getChatRoomId()));
+        ChatMessageRedisDTO redisDTO = ChatMessageRedisDTO.from(requestDTO);
 
         int subscriberCount = redisSubscriber.getSubscriberCount(topic.getTopic() + "/" + requestDTO.getChatRoomId());
         log.info("[pubSendMessageChannel] - subscriberCount : {} ", subscriberCount);
         // 채팅 메시지 저장
-        ChatMessage chatMessage = chatMessageService.createMessage(requestDTO.getChatRoomId(), requestDTO);
+        ChatMessage chatMessage = chatMessageService.createMessage(requestDTO.getChatRoomId(), redisDTO);
 
-        // Message 전송
-        redisPublisher.publish(requestDTO.getChatRoomId(), requestDTO);
+        //Message 전송
+        redisPublisher.publish(redisDTO.getChatRoomId(), redisDTO);
+    }
+
+
+    // 메이트 신청/취소 전송
+    public void pubSendMessageChannel(ChatMessageRedisDTO redisDTO){
+        // 요청한 Channel 을 구독
+        listenerContainer.addMessageListener(redisSubscriber, new ChannelTopic(topic.getTopic() + "/" + redisDTO.getChatRoomId()));
+
+        // 채팅 메시지 저장
+        ChatMessage chatMessage = chatMessageService.createMessage(redisDTO.getChatRoomId(), redisDTO);
+
+        //Message 전송
+        redisPublisher.publish(redisDTO.getChatRoomId(), redisDTO);
     }
 
     /**

--- a/src/main/java/com/otclub/humate/domain/chat/vo/ChatMessage.java
+++ b/src/main/java/com/otclub/humate/domain/chat/vo/ChatMessage.java
@@ -1,5 +1,6 @@
 package com.otclub.humate.domain.chat.vo;
 
+import com.otclub.humate.domain.chat.dto.ChatMessageRedisDTO;
 import com.otclub.humate.domain.chat.dto.ChatMessageRequestDTO;
 import java.time.LocalDateTime;
 import java.util.Calendar;
@@ -46,7 +47,7 @@ public class ChatMessage {
     private MessageType messageType; // 채팅 타입 필드 추가('TEXT', 'IMAGE')
     private String imgUrl;
 
-    public static ChatMessage of(String chatRoomId, ChatMessageRequestDTO requestDTO){
+    public static ChatMessage of(String chatRoomId, ChatMessageRedisDTO requestDTO){
         ChatMessage chatMessage = ChatMessage.builder()
                 .chatRoomId(chatRoomId)
                 .senderId(requestDTO.getSenderId())

--- a/src/main/java/com/otclub/humate/domain/chat/vo/MessageType.java
+++ b/src/main/java/com/otclub/humate/domain/chat/vo/MessageType.java
@@ -20,18 +20,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MessageType {
-    TEXT(0),
-    IMAGE(1),
-    ENTER(2),
-    EXIT(3);
+    TEXT(0 , ""),
+    IMAGE(1, ""),
+    ENTER(2, " 님이 입장했습니다."),
+    EXIT(3, " 님이 나갔습니다."),
+    MATE_ACTIVE(4, " 님이 메이트 신청을 했습니다."),
+    MATE_INACTIVE(5, " 님이 메이트 신청을 취소했습니다.");
 
     private final Integer type;
-
-//    @JsonCreator
-//    public static MessageType of(Integer chatType){
-//        return Arrays.stream(MessageType.values())
-//                .filter(i -> i.getType().equals(chatType))
-//                .findAny()
-//                .orElse(null);
-//    }
+    private final String msg;
 }

--- a/src/main/java/com/otclub/humate/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/otclub/humate/domain/member/mapper/MemberMapper.java
@@ -26,4 +26,5 @@ public interface MemberMapper {
     public int updateRefreshToken(Member member);
     public Member selectMemberById(String memberId);
     public Member selectMemberByPhone(String phone);
+    public Member selectMemberDetail(String memberId);
 }

--- a/src/main/java/com/otclub/humate/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/otclub/humate/domain/member/mapper/MemberMapper.java
@@ -3,6 +3,7 @@ package com.otclub.humate.domain.member.mapper;
 import com.otclub.humate.common.entity.Member;
 import com.otclub.humate.domain.auth.dto.LogInRequestDTO;
 import com.otclub.humate.domain.auth.dto.SignUpRequestDTO;
+import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 
 /**
@@ -26,5 +27,5 @@ public interface MemberMapper {
     public int updateRefreshToken(Member member);
     public Member selectMemberById(String memberId);
     public Member selectMemberByPhone(String phone);
-    public Member selectMemberDetail(String memberId);
+    public Optional<Member> selectMemberDetail(String memberId);
 }

--- a/src/main/resources/mybatis/mapper/chat/ChatMapper.xml
+++ b/src/main/resources/mybatis/mapper/chat/ChatMapper.xml
@@ -20,4 +20,18 @@
         ]]>
     </insert>
 
+    <select id="selectChatParticipantByChatRoomIdAndMemberId" resultType="com.otclub.humate.common.entity.ChatParticipate">
+        select
+            participate_id,
+            chat_room_id,
+            member_id,
+            is_clicked
+        from
+            chat_participate
+        where
+            chat_room_id=#{chatRoomId} and
+            member_id=#{member_id} and
+            delete_at is null
+    </select>
+
 </mapper>

--- a/src/main/resources/mybatis/mapper/chat/ChatMapper.xml
+++ b/src/main/resources/mybatis/mapper/chat/ChatMapper.xml
@@ -23,15 +23,15 @@
     <select id="selectChatParticipantByChatRoomIdAndMemberId" resultType="com.otclub.humate.common.entity.ChatParticipate">
         select
             participate_id,
-            chat_room_id,
             member_id,
+            chat_room_id,
             is_clicked
         from
             chat_participate
         where
             chat_room_id=#{chatRoomId} and
-            member_id=#{member_id} and
-            delete_at is null
+            member_id=#{memberId} and
+            deleted_at is null
     </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mapper/chat/MateMapper.xml
+++ b/src/main/resources/mybatis/mapper/chat/MateMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.otclub.humate.domain.chat.mapper.MateMapper">
+
+    <update id="updateMate" parameterType="com.otclub.humate.domain.chat.dto.MateCreateRequestDTO">
+        update chat_participate
+        set is_clicked = #{isClicked}
+        where chat_room_id = #{chatRoomId} and member_id = #{memberId}
+    </update>
+
+<!--    <insert id="insertChatParticipant" parameterType="com.otclub.humate.common.entity.ChatParticipate">-->
+<!--        <![CDATA[-->
+<!--            insert into chat_participate (participate_id, member_id, chat_room_id)-->
+<!--            values (seq_chat_participate.nextval, #{memberId}, #{chatRoomId})-->
+<!--        ]]>-->
+<!--    </insert>-->
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mybatis/mapper/member/MemberMapper.xml
@@ -99,12 +99,13 @@
             phone=#{phone}
     </select>
 
-    <select id="selectMemberDetail">
+    <select id="selectMemberDetail" resultType="com.otclub.humate.common.entity.Member">
         select
             *
         from
             member
         where
-            member_id=#{memberId}
+            member_id=#{memberId} and
+            deleted_at is null
     </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mybatis/mapper/member/MemberMapper.xml
@@ -98,4 +98,13 @@
         where
             phone=#{phone}
     </select>
+
+    <select id="selectMemberDetail">
+        select
+            *
+        from
+            member
+        where
+            member_id=#{memberId}
+    </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
메이트 맺기 API 구현했습니다. 채팅방으로 채팅(공지) 보내는 것까지 완료했습니다. 

## ⭐️ 관련 이슈
- closes : #34 

## 📍 작업한 내용
- 메이트 맺기, 취소하기 API 구현
- Redis 채팅 요청 시 동일한 DTO로 보내게 구현
- 메이트 맺기/취소 예외 처리

## 🔎 결과 및 이슈 공유
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/c435c3e2-5b3c-4a76-a71f-65a2f25fefca">

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/ec7406d5-b5a9-442b-b5e2-823a819624ff">

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/98159ce4-3df4-43fd-a6f7-5fba9beec26d">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
