### PR TITLE
[MATE] 매칭글 상세 조회 시 이미지 프로필 필드 추가

### DIFF
--- a/src/main/java/com/otclub/humate/domain/mate/dto/PostBasicDetailResponseDTO.java
+++ b/src/main/java/com/otclub/humate/domain/mate/dto/PostBasicDetailResponseDTO.java
@@ -13,6 +13,8 @@ public class PostBasicDetailResponseDTO {
 
     // 회원 고유번호
     private String memberId;
+    // 회원 프로필 이미지
+    private String profileImgUrl;
     // 게시글 제목
     private String title;
     // 게시글 내용

--- a/src/main/java/com/otclub/humate/domain/mate/dto/PostDetailResponseDTO.java
+++ b/src/main/java/com/otclub/humate/domain/mate/dto/PostDetailResponseDTO.java
@@ -17,6 +17,8 @@ public class PostDetailResponseDTO {
     private int postId;
     // 회원 고유번호
     private String memberId;
+    // 회원 프로필 이미지
+    private String profileImgUrl;
     // 게시글 제목
     private String title;
     // 게시글 내용

--- a/src/main/java/com/otclub/humate/domain/mate/service/PostServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/mate/service/PostServiceImpl.java
@@ -164,6 +164,7 @@ public class PostServiceImpl implements PostService {
                 = PostDetailResponseDTO.builder()
                 .postId(postId)
                 .memberId(postBasic.getMemberId())
+                .profileImgUrl(postBasic.getProfileImgUrl())
                 .title(postBasic.getTitle())
                 .content(postBasic.getContent())
                 .matchDate(postBasic.getMatchDate())

--- a/src/main/resources/mybatis/mapper/mate/PostMapper.xml
+++ b/src/main/resources/mybatis/mapper/mate/PostMapper.xml
@@ -163,11 +163,12 @@
     <select id="selectPostById" resultType="com.otclub.humate.domain.mate.dto.PostBasicDetailResponseDTO">
         <![CDATA[
             select
-                member_id, title, content,
-                match_date, match_branch, match_gender, match_language,
-                is_matched
-            from post
-            where post_id = #{postId}
+                p.member_id, p.title, p.content,
+                p.match_date, p.match_branch, p.match_gender, p.match_language, p.is_matched,
+                m.profile_img_url as profileImgUrl
+            from post p
+                join member m on p.member_id = m.member_id
+            where p.post_id = #{postId}
         ]]>
     </select>
 


### PR DESCRIPTION
# 💡 PR 요약
매칭글 상세 조회 시 프로필 이미지를 화면에 출력해야 하기 때문에 responseDTO 필드 수정

## ⭐️ 관련 이슈
- closes : #65 

## 📍 작업한 내용
- PostBasicDetailResponseDTO, PostDetailResponseDTO에 profileImgUrl 필드 추가
- 쿼리 수정 (member table과 조인)

## 🔎 결과 및 이슈 공유
<img width="975" alt="image" src="https://github.com/user-attachments/assets/cbb81fe0-41c6-4c7d-a245-0abceeb42e7d">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
