### PR TITLE
[ACTIVITY] 활동 목록 반환 데이터 및 로직 개선

### DIFF
--- a/src/main/java/com/otclub/humate/domain/activity/dto/CompanionActivityHistoryDetailsResponseDTO.java
+++ b/src/main/java/com/otclub/humate/domain/activity/dto/CompanionActivityHistoryDetailsResponseDTO.java
@@ -15,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 public class CompanionActivityHistoryDetailsResponseDTO {
     private String activityTitle;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
     private Date createdAt;
     private List<String> imgUrls;
 }

--- a/src/main/java/com/otclub/humate/domain/activity/dto/CompanionInfoDTO.java
+++ b/src/main/java/com/otclub/humate/domain/activity/dto/CompanionInfoDTO.java
@@ -1,0 +1,14 @@
+package com.otclub.humate.domain.activity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CompanionInfoDTO {
+    private String postTitle;
+    private int isFinished;
+
+}

--- a/src/main/java/com/otclub/humate/domain/activity/dto/MissionResponseDTO.java
+++ b/src/main/java/com/otclub/humate/domain/activity/dto/MissionResponseDTO.java
@@ -11,17 +11,19 @@ import java.util.List;
 @Setter
 @Builder
 public class MissionResponseDTO {
+    private int isFinished;
     private String postTitle;
     private List<ClearedMissionDTO> clearedMissionList;
     private List<NewMissionDTO> newMissionList;
 
     public static MissionResponseDTO of(List<ClearedMissionDTO> companionActivityHistories,
                                         List<Activity> activities,
-                                        String postTitle) {
+                                        CompanionInfoDTO companionInfoDTO) {
         return MissionResponseDTO.builder()
                 .clearedMissionList(companionActivityHistories)
                 .newMissionList(NewMissionDTO.ofList(activities))
-                .postTitle(postTitle)
+                .postTitle(companionInfoDTO.getPostTitle())
+                .isFinished(companionInfoDTO.getIsFinished())
                 .build();
     }
 }

--- a/src/main/java/com/otclub/humate/domain/activity/service/ActivityServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/activity/service/ActivityServiceImpl.java
@@ -28,7 +28,7 @@ public class ActivityServiceImpl implements ActivityService {
     public MissionResponseDTO findActivities(int companionId) {
 
         // 글 제목 조회
-        String postTitle = companionMapper.selectPostTitleById(companionId);
+        CompanionInfoDTO companionInfoDTO = companionMapper.selectPostTitleById(companionId);
 
         // 완료된 활동 목록과 새로운 활동 목록 2개를 조회해야한다.
         List<ClearedMissionDTO> companionActivityHistories = activityMapper.selectCompanionActivityHistoryList(companionId);
@@ -44,7 +44,7 @@ public class ActivityServiceImpl implements ActivityService {
             }
         }
 
-        return MissionResponseDTO.of(companionActivityHistories, activities, postTitle);
+        return MissionResponseDTO.of(companionActivityHistories, activities, companionInfoDTO);
     }
 
     @Override

--- a/src/main/java/com/otclub/humate/domain/companion/mapper/CompanionMapper.java
+++ b/src/main/java/com/otclub/humate/domain/companion/mapper/CompanionMapper.java
@@ -1,6 +1,7 @@
 package com.otclub.humate.domain.companion.mapper;
 
 import com.otclub.humate.common.entity.Companion;
+import com.otclub.humate.domain.activity.dto.CompanionInfoDTO;
 import com.otclub.humate.domain.companion.dto.CompanionDetailsDTO;
 import com.otclub.humate.domain.companion.dto.CompanionPostDTO;
 import org.apache.ibatis.annotations.Mapper;
@@ -23,5 +24,5 @@ public interface CompanionMapper {
 
     List<CompanionDetailsDTO> selectCompanionListByMemberId(String memberId);
 
-    String selectPostTitleById(int companionId);
+    CompanionInfoDTO selectPostTitleById(int companionId);
 }

--- a/src/main/resources/mybatis/mapper/companion/CompanionMapper.xml
+++ b/src/main/resources/mybatis/mapper/companion/CompanionMapper.xml
@@ -67,12 +67,13 @@
         order by c.finished_at desc
     </select>
 
-    <select id="selectPostTitleById" resultType="java.lang.String">
+    <select id="selectPostTitleById" resultType="com.otclub.humate.domain.activity.dto.CompanionInfoDTO">
         select
-            r.post_title
+            r.post_title,
+           NVL2(c.FINISHED_AT, 1, 0) is_finished
         from companion c
-        join chat_room r
-        on c.chat_room_id = r.chat_room_id
+             join chat_room r
+                on c.chat_room_id = r.chat_room_id
         where c.companion_id = #{companionId}
     </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
활동 목록 반환 시 종료된 동행인지 아닌지에 대한 데이터도 추가했습니다.

## ⭐️ 관련 이슈
- closes : #67 

## 📍 작업한 내용
- 전체적인 활동 목록 반환 로직 수정

## 🔎 결과 및 이슈 공유
![image](https://github.com/user-attachments/assets/22d828f4-d43c-42ba-a75f-3ed9da216eb1)

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. 
