### PR TITLE
[MEMBER] 회원 수정 시 Request를 Multipart file로 받게 변경

### DIFF
--- a/src/main/java/com/otclub/humate/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/auth/service/AuthServiceImpl.java
@@ -46,6 +46,7 @@ import static com.otclub.humate.domain.auth.util.AuthUtil.*;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthServiceImpl implements AuthService {
 
     private final MemberMapper mapper;

--- a/src/main/java/com/otclub/humate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/otclub/humate/domain/member/controller/MemberController.java
@@ -2,14 +2,17 @@ package com.otclub.humate.domain.member.controller;
 
 import com.otclub.humate.common.annotation.MemberId;
 import com.otclub.humate.common.dto.CommonResponseDTO;
+import com.otclub.humate.domain.auth.dto.SignUpRequestDTO;
 import com.otclub.humate.domain.member.dto.MateDetailResponseDTO;
 import com.otclub.humate.domain.member.dto.ModifyProfileRequestDTO;
 import com.otclub.humate.domain.member.dto.ProfileResponseDTO;
 import com.otclub.humate.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -65,10 +68,12 @@ public class MemberController {
      *
      * @author 조영욱
      */
-    @PutMapping("/profile")
+    @PutMapping(value = "/profile", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<CommonResponseDTO> modifyMyProfile(
-            @RequestBody ModifyProfileRequestDTO dto, @MemberId String memberId) {
-        return service.modifyMyProfile(dto, memberId) ?
+            @RequestPart("modifyProfileRequestDTO") ModifyProfileRequestDTO dto,
+            @RequestPart(value="image", required=false) MultipartFile image,
+            @MemberId String memberId) {
+        return service.modifyMyProfile(dto, image, memberId) ?
                 ResponseEntity.ok(new CommonResponseDTO(true, "수정에 성공하였습니다.")) :
                 ResponseEntity.ok(new CommonResponseDTO(false, "수정에 실패하였습니다."));
     }

--- a/src/main/java/com/otclub/humate/domain/member/service/MemberService.java
+++ b/src/main/java/com/otclub/humate/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.otclub.humate.domain.member.service;
 import com.otclub.humate.domain.member.dto.MateDetailResponseDTO;
 import com.otclub.humate.domain.member.dto.ModifyProfileRequestDTO;
 import com.otclub.humate.domain.member.dto.ProfileResponseDTO;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -22,6 +23,6 @@ import java.util.List;
 public interface MemberService {
     boolean checkAvailableNickname(String nickname);
     ProfileResponseDTO getMemberProfile(String memberId);
-    boolean modifyMyProfile(ModifyProfileRequestDTO dto, String memberId);
+    boolean modifyMyProfile(ModifyProfileRequestDTO dto, MultipartFile image, String memberId);
     List<MateDetailResponseDTO> getMyMates(String memberId);
 }


### PR DESCRIPTION
# 💡 PR 요약
회원 수정 시 파일을 받아 image 수정을 위해 Request를 Multipart file로 받게 변경하였습니다.

## ⭐️ 관련 이슈
- closes : #74 

## 📍 작업한 내용
- 회원 수정 시 Request를 Multipart file로 받게 변경

## 🔎 결과 및 이슈 공유

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
