### PR TITLE
[REVIEW] 후기 등록 시 매너 점수 반영 및 로직 프로시저로 변경

### DIFF
--- a/src/main/java/com/otclub/humate/common/entity/Review.java
+++ b/src/main/java/com/otclub/humate/common/entity/Review.java
@@ -14,8 +14,9 @@ public class Review {
     private String reviewerId;
     private String revieweeId;
     private String content;
-    private int score;
+    private double score;
     private Date createdAt;
+    private String status;
 
     public static Review of(ReviewRequestDTO reviewRequestDTO, Companion companion, String memberId) {
         ReviewBuilder reviewBuilder = Review.builder()

--- a/src/main/java/com/otclub/humate/domain/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/otclub/humate/domain/review/dto/ReviewRequestDTO.java
@@ -3,12 +3,11 @@ package com.otclub.humate.domain.review.dto;
 import lombok.*;
 
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
 public class ReviewRequestDTO {
     private int companionId;
     private String content;
-    private int score;
+    private double score;
 }

--- a/src/main/java/com/otclub/humate/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/otclub/humate/domain/review/mapper/ReviewMapper.java
@@ -5,5 +5,5 @@ import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface ReviewMapper {
-    int insertReview(Review review);
+    void insertReviewAndUpdateManner(Review review);
 }

--- a/src/main/java/com/otclub/humate/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/review/service/ReviewServiceImpl.java
@@ -37,7 +37,9 @@ public class ReviewServiceImpl implements ReviewService {
                 .selectCompanionByIds(reviewRequestDTO.getCompanionId(), memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXISTS_COMPANION));
 
-        if (reviewMapper.insertReview(Review.of(reviewRequestDTO, companion, memberId)) != 1) {
+        Review review = Review.of(reviewRequestDTO, companion, memberId);
+        reviewMapper.insertReviewAndUpdateManner(review);
+        if (review.getStatus().equals("Failure")) {
             throw new CustomException(ErrorCode.REVIEW_FAIL);
         }
     }

--- a/src/main/resources/mybatis/mapper/review/ReviewMapper.xml
+++ b/src/main/resources/mybatis/mapper/review/ReviewMapper.xml
@@ -2,8 +2,18 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.otclub.humate.domain.review.mapper.ReviewMapper">
-    <insert id="insertReview">
-        insert into review(review_id, companion_id, reviewer_id, reviewee_id, content, score)
-        values (seq_review.nextval, #{companionId}, #{reviewerId}, #{revieweeId}, #{content}, #{score})
-    </insert>
+    <select id="insertReviewAndUpdateManner"
+            statementType="CALLABLE"
+            parameterType="com.otclub.humate.common.entity.Review">
+        {
+            call insertReviewAndUpdateMannerProc(
+                #{companionId, mode=IN, jdbcType=INTEGER},
+                #{reviewerId, mode=IN, jdbcType=VARCHAR},
+                #{revieweeId, mode=IN, jdbcType=VARCHAR},
+                #{content, mode=IN, jdbcType=VARCHAR},
+                #{score, mode=IN, jdbcType=DOUBLE},
+                #{status, mode=OUT, jdbcType=VARCHAR}
+            )
+        }
+    </select>
 </mapper>


### PR DESCRIPTION
# 💡 PR 요약
후기 등록 시 회원(상대방)의 매너 점수에 반영되도록 로직을 변경했습니다.
또한, 해당 로직을 프로시저로 묶었습니다.

## ⭐️ 관련 이슈
- closes : #76 

## 📍 작업한 내용
- 후기 등록 시 상대방 매너 점수에 반영
- 후기 등록 로직 프로시저로 변경

## 🔎 결과 및 이슈 공유


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
