### PR TITLE
[ACTIVITY] 활동 검증 쿼리 개선 및 S3 Upload 비동기 처리

### DIFF
--- a/src/main/java/com/otclub/humate/common/config/AsyncConfig.java
+++ b/src/main/java/com/otclub/humate/common/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.otclub.humate.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+    @Bean("S3ImageUploadExecutor")
+    public Executor imageUploadExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadGroupName("S3ImageUploadExecutor");
+        executor.setCorePoolSize(Runtime.getRuntime().availableProcessors() * 2);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(50);
+        executor.initialize();
+
+        return executor;
+    }
+}

--- a/src/main/java/com/otclub/humate/common/exception/ErrorCode.java
+++ b/src/main/java/com/otclub/humate/common/exception/ErrorCode.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
     DUPLICATE_KEY(409, "중복되는 아이디나 닉네임이 존재합니다. 다시 시도해주세요."),
     UPLOAD_FAIL(400, "사진 업로드에 실패했습니다."),
-    ALREADY_EXISTS_ACTIVITY(409, "이미 존재하는 활동입니다. 다른 활동을 등록해 주세요."),
+    ALREADY_EXISTS_ACTIVITY(409, "이미 등록한 활동이거나 동행이 종료되었습니다. 다른 활동을 등록해 주세요."),
     CANCEL_COMPANION_FAIL(400, "동행 취소에 실패했습니다."),
     NOT_EXISTS_COMPANION(400, "존재하지 않는 동행입니다."),
     REVIEW_FAIL(400, "리뷰 등록에 실패했습니다."),

--- a/src/main/java/com/otclub/humate/common/upload/S3Uploader.java
+++ b/src/main/java/com/otclub/humate/common/upload/S3Uploader.java
@@ -36,7 +36,7 @@ public class S3Uploader {
         return amazonS3.getUrl(bucket, uploadName).toString();
     }
 
-    @Async
+    @Async("S3ImageUploadExecutor")
     public void uploadToS3(MultipartFile imageFile, String uploadName) throws IOException {
         amazonS3.putObject(new PutObjectRequest(
                 bucket,

--- a/src/main/java/com/otclub/humate/domain/activity/mapper/ActivityMapper.java
+++ b/src/main/java/com/otclub/humate/domain/activity/mapper/ActivityMapper.java
@@ -25,7 +25,7 @@ public interface ActivityMapper {
 
     List<String> selectImgUrlListById(int companionActivityId);
 
-    int countCompanionActivityHistoryByIds(@Param("companionId") int companionId,
+    int validateInsertCompanionActivity(@Param("companionId") int companionId,
                                         @Param("activityId") int activityId);
     int insertCompanionActivityHistory(CompanionActivityHistory companionActivityHistory);
 

--- a/src/main/java/com/otclub/humate/domain/activity/service/ActivityServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/activity/service/ActivityServiceImpl.java
@@ -71,6 +71,7 @@ public class ActivityServiceImpl implements ActivityService {
     public void saveCompanionActivityHistory(UploadActivityRequestDTO uploadActivityRequestDTO,
                                              List<MultipartFile> images,
                                              String memberId) {
+
         int companionId = uploadActivityRequestDTO.getCompanionId();
         int activityId = uploadActivityRequestDTO.getActivityId();
         isAlreadyUploadedCompanionActivityHistory(companionId, activityId);

--- a/src/main/java/com/otclub/humate/domain/activity/service/ActivityServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/activity/service/ActivityServiceImpl.java
@@ -74,7 +74,11 @@ public class ActivityServiceImpl implements ActivityService {
 
         int companionId = uploadActivityRequestDTO.getCompanionId();
         int activityId = uploadActivityRequestDTO.getActivityId();
-        isAlreadyUploadedCompanionActivityHistory(companionId, activityId);
+
+        // 동행이 종료되었거나, 이미 등록한 활동인지 검증
+        if (activityMapper.validateInsertCompanionActivity(companionId, activityId) != 0) {
+            throw new CustomException(ErrorCode.ALREADY_EXISTS_ACTIVITY);
+        }
 
         // 유효한 회원인지 검증
         if (companionMapper.countCompanionByMemberIdAndCompanionId(memberId, companionId) == 0) {
@@ -98,12 +102,6 @@ public class ActivityServiceImpl implements ActivityService {
         // bulk insert
         if (activityMapper.insertCompanionActivityImgList(companionActivityImgList) != companionActivityImgList.size()) {
             throw new CustomException(ErrorCode.UPLOAD_FAIL);
-        }
-    }
-
-    private void isAlreadyUploadedCompanionActivityHistory(int companionId, int activityId) {
-        if (activityMapper.countCompanionActivityHistoryByIds(companionId, activityId) != 0) {
-            throw new CustomException(ErrorCode.ALREADY_EXISTS_ACTIVITY);
         }
     }
 }

--- a/src/main/java/com/otclub/humate/domain/companion/dto/CompanionDetailsDTO.java
+++ b/src/main/java/com/otclub/humate/domain/companion/dto/CompanionDetailsDTO.java
@@ -20,4 +20,5 @@ public class CompanionDetailsDTO {
     private String secondMemberNickname;
     private String postTitle;
     private String matchDate;
+    private String matchBranch;
 }

--- a/src/main/java/com/otclub/humate/domain/companion/dto/CompanionResponseDTO.java
+++ b/src/main/java/com/otclub/humate/domain/companion/dto/CompanionResponseDTO.java
@@ -15,6 +15,7 @@ public class CompanionResponseDTO {
     private String mateProfileImgUrl;  // 상대방 프로필 이미지
     private String mateNickname;  // 상대방 이름
     private String matchDate;  // 동행 날짜
+    private String matchBranch;
     private String status;  // 동행 상태
 
     public static List<CompanionResponseDTO> ofList(
@@ -26,6 +27,7 @@ public class CompanionResponseDTO {
             CompanionResponseDTOBuilder responseBuilder = CompanionResponseDTO.builder()
                     .companionId(companionDetailsDTO.getCompanionId())
                     .matchDate(companionDetailsDTO.getMatchDate())
+                    .matchBranch(companionDetailsDTO.getMatchBranch())
                     .postTitle(companionDetailsDTO.getPostTitle())
                     .status(
                             companionDetailsDTO.getFinishedAt() != null ?

--- a/src/main/resources/mybatis/mapper/activity/ActivityMapper.xml
+++ b/src/main/resources/mybatis/mapper/activity/ActivityMapper.xml
@@ -57,19 +57,33 @@
         where companion_activity_id = #{companionActivityId}
     </select>
 
-    <select id="countCompanionActivityHistoryByIds" resultType="java.lang.Integer">
-        select
-            count(ca.companion_activity_id)
-        from
-            companion_activity_history ca
-        join
-            companion c
-        on
-            ca.companion_id = c.companion_id
-        where
-            c.companion_id = #{companionId}
-            and ca.activity_id = #{activityId}
-            and c.finished_at is null
+    <select id="validateInsertCompanionActivity" resultType="java.lang.Integer">
+        SELECT
+            CASE
+        WHEN EXISTS(
+                SELECT
+                    1
+                FROM
+                    companion c
+                WHERE
+                    c.companion_id = 4
+                      AND c.finished_at IS NOT NULL
+            ) THEN 1
+        WHEN EXISTS(
+                SELECT
+                    1
+                FROM
+                    companion_activity_history ca
+                JOIN
+                    companion c
+                ON
+                    ca.companion_id = c.companion_id
+               WHERE
+                   c.companion_id = 4
+                 AND ca.activity_id = 1
+            ) THEN 1
+        ELSE 0 END AS validate_companion
+        from dual
     </select>
 
     <insert id="insertCompanionActivityHistory" parameterType="com.otclub.humate.common.entity.CompanionActivityHistory"

--- a/src/main/resources/mybatis/mapper/activity/ActivityMapper.xml
+++ b/src/main/resources/mybatis/mapper/activity/ActivityMapper.xml
@@ -60,7 +60,7 @@
     <select id="validateInsertCompanionActivity" resultType="java.lang.Integer">
         SELECT
             CASE
-        WHEN EXISTS(
+            WHEN EXISTS(
                 SELECT
                     1
                 FROM
@@ -69,7 +69,7 @@
                     c.companion_id = 4
                       AND c.finished_at IS NOT NULL
             ) THEN 1
-        WHEN EXISTS(
+            WHEN EXISTS(
                 SELECT
                     1
                 FROM
@@ -82,7 +82,7 @@
                    c.companion_id = 4
                  AND ca.activity_id = 1
             ) THEN 1
-        ELSE 0 END AS validate_companion
+            ELSE 0 END AS validate_companion
         from dual
     </select>
 

--- a/src/main/resources/mybatis/mapper/activity/ActivityMapper.xml
+++ b/src/main/resources/mybatis/mapper/activity/ActivityMapper.xml
@@ -58,9 +58,18 @@
     </select>
 
     <select id="countCompanionActivityHistoryByIds" resultType="java.lang.Integer">
-        select count(companion_activity_id)
-        from companion_activity_history
-        where companion_id = #{companionId} and activity_id = #{activityId}
+        select
+            count(ca.companion_activity_id)
+        from
+            companion_activity_history ca
+        join
+            companion c
+        on
+            ca.companion_id = c.companion_id
+        where
+            c.companion_id = #{companionId}
+            and ca.activity_id = #{activityId}
+            and c.finished_at is null
     </select>
 
     <insert id="insertCompanionActivityHistory" parameterType="com.otclub.humate.common.entity.CompanionActivityHistory"

--- a/src/main/resources/mybatis/mapper/companion/CompanionMapper.xml
+++ b/src/main/resources/mybatis/mapper/companion/CompanionMapper.xml
@@ -55,7 +55,8 @@
             sm.profile_img_url second_member_profile_img_url,
             sm.nickname second_member_nickname,
             cr.post_title,
-            cr.match_date
+            cr.match_date,
+            cr.match_branch
         from companion c
                  join member fm
                       on c.first_member_id = fm.member_id


### PR DESCRIPTION
# 💡 PR 요약
동행이 종료되었다면 새로운 미션을 업로드할 수 없도록 설정했습니다.
동행 목록 데이터 반환 시 match_branch 도 담아서 반환
S3 Upload 시 async로 비동기 호출하도록 하였습니다.
이때, 적정 스레드 풀에 대한 고민은 깊게 하지 못해, 일단 system 코어 개수 *2로 스레드 개수를 설정했습니다.

## ⭐️ 관련 이슈
- closes : #88 

## 📍 작업한 내용
- [x] 동행이 종료되었거나, 이미 업로드한 활동이라면 등록할 수 없도록 로직 개선
- [x] 동행 목록 데이터 반환 시 match_branch 추가
- [x] S3 Upload 비동기 처리

## 🔎 결과 및 이슈 공유
![image](https://github.com/user-attachments/assets/0866e6f8-9466-45f5-be0e-56145ff8c3c2)
![image](https://github.com/user-attachments/assets/bce35167-dc7d-476c-b155-cfc50f73e8cb)


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
