### PR TITLE
[CHAT] WebSocket 필터 제거, 동행되면 isMatched 값 바꾸기, 채팅방 생성 시 글 정보 넣어주기

### DIFF
--- a/src/main/java/com/otclub/humate/common/config/SecurityConfig.java
+++ b/src/main/java/com/otclub/humate/common/config/SecurityConfig.java
@@ -60,11 +60,6 @@ public class SecurityConfig {
                 "/auth/signup","/auth/login",
                 "/auth/**",
                 "/members/check-nickname",
-                "/posts/**",
-                "/rooms/**",
-                "/redis/**",
-                "/chat/**",
-                "/ws/**",
-                "/mate/**");
+                "/posts/**");
     }
 }

--- a/src/main/java/com/otclub/humate/common/entity/ChatRoom.java
+++ b/src/main/java/com/otclub/humate/common/entity/ChatRoom.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 /**
  * 채팅방 Entity
@@ -22,6 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@ToString
 public class ChatRoom {
     private int chatRoomId;
     private int postId;
@@ -32,9 +34,12 @@ public class ChatRoom {
     private int isMatched;
     private Date createdAt;
 
-    public static ChatRoom from(int postId){
+    public static ChatRoom from(Post post){
         return ChatRoom.builder()
-                .postId(postId)
+                .postId(post.getPostId())
+                .postTitle(post.getTitle() == null ? "-" : post.getTitle())
+                .matchDate(post.getMatchDate() == null ? "-" : post.getMatchDate())
+                .matchBranch(post.getMatchBranch() == null ? "-" : post.getMatchBranch())
                 .build();
     }
 }

--- a/src/main/java/com/otclub/humate/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/otclub/humate/domain/chat/controller/ChatRoomController.java
@@ -3,15 +3,13 @@ package com.otclub.humate.domain.chat.controller;
 import com.otclub.humate.common.annotation.MemberId;
 import com.otclub.humate.domain.chat.dto.ChatRoomCreateRequestDTO;
 import com.otclub.humate.domain.chat.dto.ChatRoomCreateResponseDTO;
-import com.otclub.humate.domain.chat.dto.ChatRoomDetailDTO;
+import com.otclub.humate.domain.chat.dto.ChatRoomDetailResponseDTO;
 import com.otclub.humate.domain.chat.service.ChatRoomService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,17 +45,17 @@ public class ChatRoomController {
     }
 
     @ResponseBody
-    @GetMapping("/list") // {memberId} 임시
-    public ResponseEntity<List<ChatRoomDetailDTO>> chatRoomList(@MemberId String memberId){
-        List<ChatRoomDetailDTO> roomList = chatRoomService.findChatRoomList(memberId, 1);
+    @GetMapping("/list")
+    public ResponseEntity<List<ChatRoomDetailResponseDTO>> chatRoomList(@MemberId String memberId){
+        List<ChatRoomDetailResponseDTO> roomList = chatRoomService.findChatRoomList(memberId, 1);
 
         return ResponseEntity.ok(roomList);
     }
 
     @ResponseBody
-    @GetMapping("/list/pending") // {memberId} 임시
-    public ResponseEntity<List<ChatRoomDetailDTO>> chatRoomPendingList(@MemberId String memberId){
-        List<ChatRoomDetailDTO> roomList = chatRoomService.findChatRoomList(memberId, 0);
+    @GetMapping("/list/pending")
+    public ResponseEntity<List<ChatRoomDetailResponseDTO>> ㄲchatRoomPendingList(@MemberId String memberId){
+        List<ChatRoomDetailResponseDTO> roomList = chatRoomService.findChatRoomList(memberId, 0);
 
         return ResponseEntity.ok(roomList);
     }

--- a/src/main/java/com/otclub/humate/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/otclub/humate/domain/chat/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.otclub.humate.domain.chat.controller;
 
+import com.otclub.humate.common.annotation.MemberId;
 import com.otclub.humate.domain.chat.dto.ChatRoomCreateRequestDTO;
 import com.otclub.humate.domain.chat.dto.ChatRoomCreateResponseDTO;
 import com.otclub.humate.domain.chat.dto.ChatRoomDetailDTO;
@@ -39,23 +40,23 @@ public class ChatRoomController {
 
     @ResponseBody
     @PostMapping("/create")
-    public ResponseEntity<ChatRoomCreateResponseDTO> chatRoomCreate(@RequestBody ChatRoomCreateRequestDTO requestDTO){
-        ChatRoomCreateResponseDTO responseDTO = chatRoomService.createChatRoom(requestDTO);
+    public ResponseEntity<ChatRoomCreateResponseDTO> chatRoomCreate(@MemberId String memberId, @RequestBody ChatRoomCreateRequestDTO requestDTO){
+        ChatRoomCreateResponseDTO responseDTO = chatRoomService.createChatRoom(memberId, requestDTO);
 
         return ResponseEntity.ok(responseDTO);
     }
 
     @ResponseBody
-    @GetMapping("/list/{memberId}") // {memberId} 임시
-    public ResponseEntity<List<ChatRoomDetailDTO>> chatRoomList(@PathVariable("memberId") String memberId){
+    @GetMapping("/list") // {memberId} 임시
+    public ResponseEntity<List<ChatRoomDetailDTO>> chatRoomList(@MemberId String memberId){
         List<ChatRoomDetailDTO> roomList = chatRoomService.findChatRoomList(memberId, 1);
 
         return ResponseEntity.ok(roomList);
     }
 
     @ResponseBody
-    @GetMapping("/list/pending/{memberId}") // {memberId} 임시
-    public ResponseEntity<List<ChatRoomDetailDTO>> chatRoomPendingList(@PathVariable("memberId") String memberId){
+    @GetMapping("/list/pending") // {memberId} 임시
+    public ResponseEntity<List<ChatRoomDetailDTO>> chatRoomPendingList(@MemberId String memberId){
         List<ChatRoomDetailDTO> roomList = chatRoomService.findChatRoomList(memberId, 0);
 
         return ResponseEntity.ok(roomList);

--- a/src/main/java/com/otclub/humate/domain/chat/dto/ChatMessageRedisDTO.java
+++ b/src/main/java/com/otclub/humate/domain/chat/dto/ChatMessageRedisDTO.java
@@ -41,13 +41,13 @@ public class ChatMessageRedisDTO {
                 .build();
     }
 
-    public static ChatMessageRedisDTO ofMate(MateUpdateRequestDTO requestDTO){
+    public static ChatMessageRedisDTO ofMate(MateUpdateRequestDTO requestDTO, String nickname){
         MessageType messageType = (requestDTO.getIsClicked()==1 ? MessageType.MATE_ACTIVE : MessageType.MATE_INACTIVE);
 
         return ChatMessageRedisDTO.builder()
                 .chatRoomId(requestDTO.getChatRoomId())
                 .participateId(requestDTO.getParticipateId())
-                .content(messageType.getMsg())
+                .content(nickname)
                 .messageType(messageType.MATE_ACTIVE)
                 .build();
     }

--- a/src/main/java/com/otclub/humate/domain/chat/dto/ChatRoomCreateRequestDTO.java
+++ b/src/main/java/com/otclub/humate/domain/chat/dto/ChatRoomCreateRequestDTO.java
@@ -26,6 +26,6 @@ import lombok.ToString;
 @ToString
 public class ChatRoomCreateRequestDTO {
     private int postId;
-    private String applicantId;
+    //private String applicantId;
     private String writerId;
 }

--- a/src/main/java/com/otclub/humate/domain/chat/dto/ChatRoomDetailResponseDTO.java
+++ b/src/main/java/com/otclub/humate/domain/chat/dto/ChatRoomDetailResponseDTO.java
@@ -23,8 +23,9 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class ChatRoomDetailDTO {
+public class ChatRoomDetailResponseDTO {
     private int chatRoomId;
+    private String memberId;
     private int participateId;
     private int postId;
     private String postTitle;
@@ -35,6 +36,7 @@ public class ChatRoomDetailDTO {
 //    private String latestContent; // 마지막 메시지
 //    private String latestContentTime; // 마지막 메시지 전송 시간
     private String targetNickname; // 상대방 닉네임
+    private String targetMemberId;
     private String targetParticipateId;
     private String targetProfileImgUrl; // 상대방 프로필
     private int targetIsClicked; // 상대방 메이트 맺기 클릭 여부

--- a/src/main/java/com/otclub/humate/domain/chat/mapper/ChatRoomMapper.java
+++ b/src/main/java/com/otclub/humate/domain/chat/mapper/ChatRoomMapper.java
@@ -2,7 +2,7 @@ package com.otclub.humate.domain.chat.mapper;
 
 import com.otclub.humate.common.entity.ChatParticipate;
 import com.otclub.humate.common.entity.ChatRoom;
-import com.otclub.humate.domain.chat.dto.ChatRoomDetailDTO;
+import com.otclub.humate.domain.chat.dto.ChatRoomDetailResponseDTO;
 import java.util.List;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
@@ -28,7 +28,7 @@ public interface ChatRoomMapper {
     Optional<ChatParticipate> selectChatParticipantByParticipateId(
             @Param("participateId") String participateId);
 
-    List<ChatRoomDetailDTO> selectChatList(
+    List<ChatRoomDetailResponseDTO> selectChatList(
             @Param("memberId") String memberId,
             @Param("isMatched") int isMatched);
 

--- a/src/main/java/com/otclub/humate/domain/chat/mapper/ChatRoomMapper.java
+++ b/src/main/java/com/otclub/humate/domain/chat/mapper/ChatRoomMapper.java
@@ -40,4 +40,8 @@ public interface ChatRoomMapper {
 
     List<String> selectChatRoomMemberById(int chatRoomId);
 
+    int selectParticipatesClickCount(@Param("chatRoomId") String chatRoomId);
+
+
+    int updateChatRoomStatus(@Param("chatRoomId")String chatRoomId);
 }

--- a/src/main/java/com/otclub/humate/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/ChatRoomService.java
@@ -2,9 +2,8 @@ package com.otclub.humate.domain.chat.service;
 
 import com.otclub.humate.domain.chat.dto.ChatRoomCreateRequestDTO;
 import com.otclub.humate.domain.chat.dto.ChatRoomCreateResponseDTO;
-import com.otclub.humate.domain.chat.dto.ChatRoomDetailDTO;
+import com.otclub.humate.domain.chat.dto.ChatRoomDetailResponseDTO;
 import java.util.List;
-import org.springframework.stereotype.Service;
 
 /**
  * 채팅방 서비스
@@ -21,5 +20,5 @@ import org.springframework.stereotype.Service;
  */
 public interface ChatRoomService {
     ChatRoomCreateResponseDTO createChatRoom(String memberId, ChatRoomCreateRequestDTO requestDTO); // 채팅방 생성
-    List<ChatRoomDetailDTO> findChatRoomList(String memberId, int isMatched);
+    List<ChatRoomDetailResponseDTO> findChatRoomList(String memberId, int isMatched);
 }

--- a/src/main/java/com/otclub/humate/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/ChatRoomService.java
@@ -20,6 +20,6 @@ import org.springframework.stereotype.Service;
  * </pre>
  */
 public interface ChatRoomService {
-    ChatRoomCreateResponseDTO createChatRoom(ChatRoomCreateRequestDTO requestDTO); // 채팅방 생성
+    ChatRoomCreateResponseDTO createChatRoom(String memberId, ChatRoomCreateRequestDTO requestDTO); // 채팅방 생성
     List<ChatRoomDetailDTO> findChatRoomList(String memberId, int isMatched);
 }

--- a/src/main/java/com/otclub/humate/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/ChatRoomServiceImpl.java
@@ -2,6 +2,7 @@ package com.otclub.humate.domain.chat.service;
 
 import com.otclub.humate.common.entity.ChatParticipate;
 import com.otclub.humate.common.entity.ChatRoom;
+import com.otclub.humate.common.entity.Post;
 import com.otclub.humate.common.exception.CustomException;
 import com.otclub.humate.common.exception.ErrorCode;
 import com.otclub.humate.domain.chat.dto.ChatRoomCreateRequestDTO;
@@ -38,19 +39,22 @@ public class ChatRoomServiceImpl implements ChatRoomService{
 
     @Override
     @Transactional
-    public ChatRoomCreateResponseDTO createChatRoom(ChatRoomCreateRequestDTO requestDTO) {
+    public ChatRoomCreateResponseDTO createChatRoom(String memberId, ChatRoomCreateRequestDTO requestDTO) {
         // postId가 유효한지 확인 후, 정보 가져오기
         int postId = requestDTO.getPostId();
+        log.info("[createChatRoom] - {}", postId);
         if (!postMapper.selectPostCountById(postId)) {
             throw new CustomException(ErrorCode.POST_NOT_FOUND);
         }
+        Post post = postMapper.selectPostByPostId(postId);
 
         // 채팅방 생성하기
-        ChatRoom chatRoom = ChatRoom.from(requestDTO.getPostId());
+        ChatRoom chatRoom = ChatRoom.from(post);
         chatRoomMapper.insertChatRoom(chatRoom);
 
+        log.info("[createChatRoom] - {}", chatRoom.toString());
         // 채팅방 참여 유저 설정하기
-        ChatParticipate applicant = ChatParticipate.of(chatRoom, requestDTO.getApplicantId());
+        ChatParticipate applicant = ChatParticipate.of(chatRoom, memberId);
         ChatParticipate writer = ChatParticipate.of(chatRoom, requestDTO.getWriterId());
 
         // 채팅방에 참여시키기

--- a/src/main/java/com/otclub/humate/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/ChatRoomServiceImpl.java
@@ -7,7 +7,7 @@ import com.otclub.humate.common.exception.CustomException;
 import com.otclub.humate.common.exception.ErrorCode;
 import com.otclub.humate.domain.chat.dto.ChatRoomCreateRequestDTO;
 import com.otclub.humate.domain.chat.dto.ChatRoomCreateResponseDTO;
-import com.otclub.humate.domain.chat.dto.ChatRoomDetailDTO;
+import com.otclub.humate.domain.chat.dto.ChatRoomDetailResponseDTO;
 import com.otclub.humate.domain.chat.mapper.ChatRoomMapper;
 import com.otclub.humate.domain.mate.mapper.PostMapper;
 import java.util.List;
@@ -65,8 +65,8 @@ public class ChatRoomServiceImpl implements ChatRoomService{
     }
 
     @Override
-    public List<ChatRoomDetailDTO> findChatRoomList(String memberId, int isMatched) {
-        List<ChatRoomDetailDTO> roomList = chatRoomMapper.selectChatList(memberId, isMatched);
+    public List<ChatRoomDetailResponseDTO> findChatRoomList(String memberId, int isMatched) {
+        List<ChatRoomDetailResponseDTO> roomList = chatRoomMapper.selectChatList(memberId, isMatched);
         return roomList;
     }
 }

--- a/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/chat/service/MateServiceImpl.java
@@ -55,8 +55,18 @@ public class MateServiceImpl implements MateService {
             throw new CustomException(ErrorCode.FORBIDDEN_REQUEST);
         }
 
+        int cnt = chatRoomMapper.selectParticipatesClickCount(requestDTO.getChatRoomId());
+        log.info("[MateServiceImpl] - selectParticipatesClickCount {} ", cnt);
+
+        if(chatRoomMapper.selectParticipatesClickCount(requestDTO.getChatRoomId())==2){
+            log.info("[MateServiceImpl] - 들어옴  ");
+            int status = chatRoomMapper.updateChatRoomStatus(requestDTO.getChatRoomId());
+            log.info("[MateServiceImpl] - updateChatRoomStatus {} ", status);
+        }
+
         // 메이트 안내 채팅 전송하기
-        ChatMessageRedisDTO redisDTO = ChatMessageRedisDTO.ofMate(requestDTO);
+        ChatMessageRedisDTO redisDTO = ChatMessageRedisDTO.ofMate(requestDTO, member.getNickname());
         chatMessageService.createMessage(redisDTO);
+
     }
 }

--- a/src/main/java/com/otclub/humate/domain/companion/controller/CompanionController.java
+++ b/src/main/java/com/otclub/humate/domain/companion/controller/CompanionController.java
@@ -2,6 +2,7 @@ package com.otclub.humate.domain.companion.controller;
 
 import com.otclub.humate.common.annotation.MemberId;
 import com.otclub.humate.common.dto.CommonResponseDTO;
+import com.otclub.humate.common.exception.ErrorCode;
 import com.otclub.humate.domain.chat.dto.ChatRoomRequestDTO;
 import com.otclub.humate.domain.companion.dto.CompanionResponseDTO;
 import com.otclub.humate.domain.companion.service.CompanionService;
@@ -23,6 +24,7 @@ public class CompanionController {
     public ResponseEntity<CommonResponseDTO> companionStart(@RequestBody ChatRoomRequestDTO chatRoomId,
                                                             @MemberId String memberId) {
         companionService.startCompanion(chatRoomId.getChatRoomId(), memberId);
+        log.error("[companionStart] {}", "완료");
         return ResponseEntity.ok(new CommonResponseDTO(true, "동행이 시작되었습니다."));
     }
 

--- a/src/main/java/com/otclub/humate/domain/companion/service/CompanionServiceImpl.java
+++ b/src/main/java/com/otclub/humate/domain/companion/service/CompanionServiceImpl.java
@@ -8,6 +8,8 @@ import com.otclub.humate.domain.companion.dto.CompanionDetailsDTO;
 import com.otclub.humate.domain.companion.dto.CompanionResponseDTO;
 import com.otclub.humate.domain.companion.mapper.CompanionMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CompanionServiceImpl implements CompanionService {
     private final CompanionMapper companionMapper;
     private final ChatRoomMapper chatRoomMapper;
@@ -43,17 +46,20 @@ public class CompanionServiceImpl implements CompanionService {
     @Transactional
     public void startCompanion(String chatRoomId, String memberId) {
         List<String> members = chatRoomMapper.selectChatRoomMemberById(Integer.parseInt(chatRoomId));
+        log.info("[startCompanion] - {}" , memberId);
         if (!members.contains(memberId)) {
+            log.error(ErrorCode.FORBIDDEN_REQUEST.getMessage());
             throw new CustomException(ErrorCode.FORBIDDEN_REQUEST);
         }
+
 
         CompanionDTO companion = CompanionDTO.of(Integer.parseInt(chatRoomId),
                                                 members.get(0),
                                                 members.get(1));
 
         if (companionMapper.insertCompanion(companion) != 1) {
+            log.error(ErrorCode.FAILED_COMPANION_START.getMessage());
             throw new CustomException(ErrorCode.FAILED_COMPANION_START);
         }
-
     }
 }

--- a/src/main/java/com/otclub/humate/domain/mate/mapper/PostMapper.java
+++ b/src/main/java/com/otclub/humate/domain/mate/mapper/PostMapper.java
@@ -40,4 +40,6 @@ public interface PostMapper {
 
     // 매칭글 삭제
     int deletePost(int postId);
+
+    Post selectPostByPostId(int postId);
 }

--- a/src/main/resources/mybatis/mapper/chat/ChatRoomMapper.xml
+++ b/src/main/resources/mybatis/mapper/chat/ChatRoomMapper.xml
@@ -36,7 +36,7 @@
             deleted_at is null
     </select>
 
-    <select id="selectChatList" resultType="com.otclub.humate.domain.chat.dto.ChatRoomDetailDTO">
+    <select id="selectChatList" resultType="com.otclub.humate.domain.chat.dto.ChatRoomDetailResponseDTO">
         <![CDATA[
             with chat_room_list as (
                 select
@@ -60,6 +60,7 @@
 
             select
                 me.chat_room_id,
+                me.member_id,
                 me.participate_id,
                 me.post_id,
                 me.post_title,
@@ -68,6 +69,7 @@
                 me.is_clicked,
                 me.is_matched,
                 nvl2(m.deleted_at, '(알수없음)', m.nickname) as target_nickname,
+                target.member_id as target_member_id,
                 target.participate_id as target_participate_id,
                 m.profile_img_url as target_profile_img_url,
                 target.is_clicked as target_is_clicked

--- a/src/main/resources/mybatis/mapper/chat/ChatRoomMapper.xml
+++ b/src/main/resources/mybatis/mapper/chat/ChatRoomMapper.xml
@@ -8,8 +8,8 @@
             SELECT seq_chat_room.nextval FROM dual
         </selectKey>
         <![CDATA[
-            insert into chat_room (chat_room_id, post_id)
-            values (#{chatRoomId}, #{postId})
+            insert into chat_room (chat_room_id, post_id, post_title, match_date, match_branch )
+            values (#{chatRoomId}, #{postId}, #{postTitle}, #{matchDate}, #{matchBranch})
         ]]>
     </insert>
 
@@ -125,4 +125,24 @@
             and c.companion_id is null
         order by p.member_id desc
     </select>
+
+
+
+    <select id="selectParticipatesClickCount">
+        select
+            count(participate_id)
+        from
+            chat_participate
+        where
+            chat_room_id = #{chatRoomId} and
+            is_clicked = 1 and
+            deleted_at is null
+    </select>
+
+
+    <update id="updateChatRoomStatus">
+        update chat_room
+        set is_matched = 1
+        where chat_room_id = #{chatRoomId}
+    </update>
 </mapper>

--- a/src/main/resources/mybatis/mapper/mate/PostMapper.xml
+++ b/src/main/resources/mybatis/mapper/mate/PostMapper.xml
@@ -246,4 +246,13 @@
         ]]>
     </update>
 
+    <select id="selectPostByPostId">
+        select
+            *
+        from
+            post
+        where
+            post_id = #{postId}
+    </select>
+
 </mapper>

--- a/src/test/java/com/otclub/humate/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/otclub/humate/domain/chat/service/ChatRoomServiceTest.java
@@ -9,16 +9,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class ChatRoomServiceTest {
     @Autowired ChatRoomService chatRoomService;
 
-    @Test
-    public void 채팅방생성(){
-        ChatRoomCreateRequestDTO requestDTO
-                = ChatRoomCreateRequestDTO.builder()
-                        .postId(1)
-                                .writerId("K_1")
-                                        .applicantId("F_1")
-                                                .build();
-
-        chatRoomService.createChatRoom(requestDTO);
-    }
+//    @Test
+//    public void 채팅방생성(){
+//        ChatRoomCreateRequestDTO requestDTO
+//                = ChatRoomCreateRequestDTO.builder()
+//                        .postId(1)
+//                                .writerId("K_1")
+//                                        .applicantId("F_1")
+//                                                .build();
+//
+//        chatRoomService.createChatRoom(requestDTO);
+//    }
 
 }


### PR DESCRIPTION
# 💡 PR 요약
메이트 채팅방 활성화 (맺기 버튼, 다이얼)

## ⭐️ 관련 이슈
- close : #94 

## 📍 작업한 내용
- 시큐리티 config에서 제거하고 memberId annotation 사용
- 채팅방에 글 정보 안들어가는 이슈 발견 
- 메이트 쌍방 신청 시 isMatched 값 업데이트 해주기

## 🔎 결과 및 이슈 공유

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
